### PR TITLE
Add note column to grades

### DIFF
--- a/app/Http/Controllers/GradeController.php
+++ b/app/Http/Controllers/GradeController.php
@@ -91,6 +91,7 @@ class GradeController extends Controller
             'assignment_score' => 'nullable|numeric|min:0|max:10',
             'semester' => 'required|string',
             'academic_year' => 'required|integer|min:2000|max:' . (date('Y') + 10),
+            'note' => 'nullable|string',
         ]);
 
         if ($validator->fails()) {
@@ -159,6 +160,7 @@ class GradeController extends Controller
             'assignment_score' => 'nullable|numeric|min:0|max:10',
             'semester' => 'required|string',
             'academic_year' => 'required|integer|min:2000|max:' . (date('Y') + 10),
+            'note' => 'nullable|string',
         ]);
 
         if ($validator->fails()) {

--- a/app/Models/Grade.php
+++ b/app/Models/Grade.php
@@ -19,6 +19,7 @@ class Grade extends Model
         'total_score',
         'semester',
         'academic_year',
+        'note',
     ];
 
     /**

--- a/database/migrations/2024_03_05_000009_add_note_to_grades_table.php
+++ b/database/migrations/2024_03_05_000009_add_note_to_grades_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('grades', function (Blueprint $table) {
+            $table->text('note')->nullable()->after('academic_year');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('grades', function (Blueprint $table) {
+            $table->dropColumn('note');
+        });
+    }
+};

--- a/tests/Feature/GradeNoteTest.php
+++ b/tests/Feature/GradeNoteTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Classes;
+use App\Models\Faculty;
+use App\Models\Grade;
+use App\Models\Major;
+use App\Models\Student;
+use App\Models\Subject;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GradeNoteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_grade_can_be_created_with_note(): void
+    {
+        $faculty = Faculty::create(['name' => 'F1', 'code' => 'F1']);
+        $major = Major::create(['name' => 'M1', 'code' => 'M1', 'faculty_id' => $faculty->id]);
+        $class = Classes::create(['name' => 'C1', 'code' => 'C1', 'major_id' => $major->id, 'year' => 2024]);
+        $student = Student::create([
+            'student_id'    => 'SV0001',
+            'first_name'    => 'A',
+            'last_name'     => 'B',
+            'date_of_birth' => '2000-01-01',
+            'gender'        => 'Nam',
+            'email'         => 'a@example.com',
+            'phone'         => '123456789',
+            'address'       => 'abc',
+            'class_id'      => $class->id,
+            'user_id'       => null,
+        ]);
+        $subject = Subject::create([
+            'name'    => 'Subj',
+            'code'    => 'SUB1',
+            'credits' => 3,
+        ]);
+
+        $grade = Grade::create([
+            'student_id'       => $student->id,
+            'subject_id'       => $subject->id,
+            'midterm_score'    => 5,
+            'final_score'      => 6,
+            'assignment_score' => 7,
+            'semester'         => 'Học kỳ 1',
+            'academic_year'    => 2024,
+            'note'             => 'Excellent',
+        ]);
+
+        $this->assertDatabaseHas('grades', [
+            'id'   => $grade->id,
+            'note' => 'Excellent',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add migration to include a nullable note column
- allow `note` to be mass assigned in Grade
- validate and store `note` in GradeController
- add a feature test for grade creation with notes

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684c76a307ec8325a0ab8a0152aa00d4