### PR TITLE
Add difficulty ratio to subjects

### DIFF
--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -53,6 +53,7 @@ class SubjectController extends Controller
             'code' => 'required|string|max:50|unique:subjects',
             'credits' => 'required|integer|min:1|max:10',
             'description' => 'nullable|string',
+            'difficulty_ratio' => 'nullable|numeric',
         ]);
 
         if ($validator->fails()) {
@@ -94,6 +95,7 @@ class SubjectController extends Controller
             'code' => 'required|string|max:50|unique:subjects,code,' . $subject->id,
             'credits' => 'required|integer|min:1|max:10',
             'description' => 'nullable|string',
+            'difficulty_ratio' => 'nullable|numeric',
         ]);
 
         if ($validator->fails()) {

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -15,6 +15,7 @@ class Subject extends Model
         'code',
         'credits',
         'description',
+        'difficulty_ratio',
     ];
 
     /**

--- a/database/migrations/2024_03_05_000013_add_difficulty_ratio_to_subjects_table.php
+++ b/database/migrations/2024_03_05_000013_add_difficulty_ratio_to_subjects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            $table->decimal('difficulty_ratio', 5, 2)->default(1)->after('credits');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            $table->dropColumn('difficulty_ratio');
+        });
+    }
+};

--- a/resources/views/subjects/create.blade.php
+++ b/resources/views/subjects/create.blade.php
@@ -44,6 +44,14 @@
                         </div>
 
                         <div class="mb-3">
+                            <label for="difficulty_ratio" class="form-label">{{ __('Độ khó') }}</label>
+                            <input type="number" step="0.1" class="form-control @error('difficulty_ratio') is-invalid @enderror" id="difficulty_ratio" name="difficulty_ratio" value="{{ old('difficulty_ratio') }}">
+                            @error('difficulty_ratio')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="mb-3">
                             <label for="description" class="form-label">{{ __('Mô tả') }}</label>
                             <textarea class="form-control @error('description') is-invalid @enderror" id="description" name="description" rows="3">{{ old('description') }}</textarea>
                             @error('description')

--- a/resources/views/subjects/edit.blade.php
+++ b/resources/views/subjects/edit.blade.php
@@ -45,6 +45,14 @@
                         </div>
 
                         <div class="mb-3">
+                            <label for="difficulty_ratio" class="form-label">{{ __('Độ khó') }}</label>
+                            <input type="number" step="0.1" class="form-control @error('difficulty_ratio') is-invalid @enderror" id="difficulty_ratio" name="difficulty_ratio" value="{{ old('difficulty_ratio', $subject->difficulty_ratio) }}">
+                            @error('difficulty_ratio')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="mb-3">
                             <label for="description" class="form-label">{{ __('Mô tả') }}</label>
                             <textarea class="form-control @error('description') is-invalid @enderror" id="description" name="description" rows="3">{{ old('description', $subject->description) }}</textarea>
                             @error('description')

--- a/resources/views/subjects/index.blade.php
+++ b/resources/views/subjects/index.blade.php
@@ -53,6 +53,7 @@
                                     <th width="15%">{{ __('Mã môn học') }}</th>
                                     <th width="35%">{{ __('Tên môn học') }}</th>
                                     <th width="10%">{{ __('Số tín chỉ') }}</th>
+                                    <th width="10%">{{ __('Độ khó') }}</th>
                                     <th width="20%">{{ __('Mô tả') }}</th>
                                     @if(auth()->user()->role == 'admin')
                                     <th width="15%">{{ __('Thao tác') }}</th>
@@ -63,10 +64,11 @@
                                 @forelse($subjects as $key => $subject)
                                 <tr>
                                     <td>{{ $subjects->firstItem() + $key }}</td>
-                                    <td>{{ $subject->code }}</td>
-                                    <td>{{ $subject->name }}</td>
-                                    <td>{{ $subject->credits }}</td>
-                                    <td>{{ Str::limit($subject->description, 50) }}</td>
+                                   <td>{{ $subject->code }}</td>
+                                   <td>{{ $subject->name }}</td>
+                                   <td>{{ $subject->credits }}</td>
+                                   <td>{{ $subject->difficulty_ratio }}</td>
+                                   <td>{{ Str::limit($subject->description, 50) }}</td>
                                     @if(auth()->user()->role == 'admin')
                                     <td>
                                         <div class="d-flex">
@@ -89,7 +91,7 @@
                                 </tr>
                                 @empty
                                 <tr>
-                                    <td colspan="{{ auth()->user()->role == 'admin' ? '6' : '5' }}" class="text-center">{{ __('Không có dữ liệu') }}</td>
+                                    <td colspan="{{ auth()->user()->role == 'admin' ? '7' : '6' }}" class="text-center">{{ __('Không có dữ liệu') }}</td>
                                 </tr>
                                 @endforelse
                             </tbody>

--- a/resources/views/subjects/show.blade.php
+++ b/resources/views/subjects/show.blade.php
@@ -35,6 +35,10 @@
                             <div class="col-md-8">{{ $subject->credits }}</div>
                         </div>
                         <div class="row mt-2">
+                            <div class="col-md-4 fw-bold">{{ __('Độ khó:') }}</div>
+                            <div class="col-md-8">{{ $subject->difficulty_ratio }}</div>
+                        </div>
+                        <div class="row mt-2">
                             <div class="col-md-4 fw-bold">{{ __('Mô tả:') }}</div>
                             <div class="col-md-8">{{ $subject->description ?: __('Không có mô tả') }}</div>
                         </div>


### PR DESCRIPTION
## Summary
- add migration to append `difficulty_ratio` field to subjects table
- allow `difficulty_ratio` mass assignment
- validate `difficulty_ratio` on create/update
- show and edit difficulty ratio in subject forms
- display difficulty ratio on index and show pages

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684c7c03f13c8325849299a4c9a307b8