### PR TITLE
Add course offering & class section models and views

### DIFF
--- a/app/Http/Controllers/ClassSectionController.php
+++ b/app/Http/Controllers/ClassSectionController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ClassSection;
+use App\Models\Subject;
+use App\Models\Teacher;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class ClassSectionController extends Controller
+{
+    public function index()
+    {
+        $sections = ClassSection::with(['subject', 'teacher.faculty'])->paginate(10);
+        return view('class_sections.index', compact('sections'));
+    }
+
+    public function create()
+    {
+        $subjects = Subject::all();
+        $teachers = Teacher::with('faculty')->get();
+        return view('class_sections.create', compact('subjects', 'teachers'));
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'code' => 'required|unique:class_sections,code',
+            'subject_id' => 'required|exists:subjects,id',
+            'teacher_id' => 'required|exists:teachers,id',
+            'room' => 'nullable|string',
+            'period_count' => 'required|integer|min:0',
+            'student_count' => 'required|integer|min:0',
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+        ClassSection::create($request->all());
+        return redirect()->route('class-sections.index')->with('success', 'Đã lưu lớp học phần.');
+    }
+
+    public function edit(ClassSection $classSection)
+    {
+        $subjects = Subject::all();
+        $teachers = Teacher::with('faculty')->get();
+        return view('class_sections.edit', compact('classSection', 'subjects', 'teachers'));
+    }
+
+    public function update(Request $request, ClassSection $classSection)
+    {
+        $validator = Validator::make($request->all(), [
+            'code' => 'required|unique:class_sections,code,' . $classSection->id,
+            'subject_id' => 'required|exists:subjects,id',
+            'teacher_id' => 'required|exists:teachers,id',
+            'room' => 'nullable|string',
+            'period_count' => 'required|integer|min:0',
+            'student_count' => 'required|integer|min:0',
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+        $classSection->update($request->all());
+        return redirect()->route('class-sections.index')->with('success', 'Đã cập nhật lớp học phần.');
+    }
+
+    public function destroy(ClassSection $classSection)
+    {
+        $classSection->delete();
+        return redirect()->route('class-sections.index')->with('success', 'Đã xóa lớp học phần.');
+    }
+
+    /**
+     * Sinh mã lớp học phần tự động và lưu.
+     */
+    public function generate(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'subject_id' => 'required|exists:subjects,id',
+            'teacher_id' => 'required|exists:teachers,id',
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $subject = Subject::find($request->subject_id);
+        $prefix = $subject->code . 'N';
+        $last = ClassSection::where('code', 'like', $prefix.'%')
+            ->orderBy('code', 'desc')
+            ->first();
+        $num = 1;
+        if ($last) {
+            $num = intval(substr($last->code, strlen($prefix))) + 1;
+        }
+        $code = $prefix . str_pad($num, 2, '0', STR_PAD_LEFT);
+
+        ClassSection::create([
+            'code' => $code,
+            'subject_id' => $request->subject_id,
+            'teacher_id' => $request->teacher_id,
+            'room' => $request->room,
+            'period_count' => $request->period_count ?? 0,
+            'student_count' => $request->student_count ?? 0,
+        ]);
+
+        return redirect()->route('class-sections.index')->with('success', 'Đã tạo lớp học phần ' . $code);
+    }
+}

--- a/app/Http/Controllers/CourseOfferingController.php
+++ b/app/Http/Controllers/CourseOfferingController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CourseOffering;
+use App\Models\Subject;
+use App\Models\Semester;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class CourseOfferingController extends Controller
+{
+    public function index()
+    {
+        $courseOfferings = CourseOffering::with(['subject', 'semester.academicYear'])->paginate(10);
+        return view('course_offerings.index', compact('courseOfferings'));
+    }
+
+    public function create()
+    {
+        $subjects = Subject::all();
+        $semesters = Semester::with('academicYear')->get();
+        return view('course_offerings.create', compact('subjects', 'semesters'));
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'subject_id' => 'required|exists:subjects,id',
+            'semester_id' => 'required|exists:semesters,id',
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+        CourseOffering::firstOrCreate($request->only('subject_id', 'semester_id'));
+        return redirect()->route('course-offerings.index')->with('success', 'Đã lưu thông tin.');
+    }
+
+    public function edit(CourseOffering $courseOffering)
+    {
+        $subjects = Subject::all();
+        $semesters = Semester::with('academicYear')->get();
+        return view('course_offerings.edit', compact('courseOffering', 'subjects', 'semesters'));
+    }
+
+    public function update(Request $request, CourseOffering $courseOffering)
+    {
+        $validator = Validator::make($request->all(), [
+            'subject_id' => 'required|exists:subjects,id',
+            'semester_id' => 'required|exists:semesters,id',
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+        $courseOffering->update($request->only('subject_id', 'semester_id'));
+        return redirect()->route('course-offerings.index')->with('success', 'Đã cập nhật thông tin.');
+    }
+
+    public function destroy(CourseOffering $courseOffering)
+    {
+        $courseOffering->delete();
+        return redirect()->route('course-offerings.index')->with('success', 'Đã xóa thành công.');
+    }
+}

--- a/app/Models/ClassSection.php
+++ b/app/Models/ClassSection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ClassSection extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'code',
+        'subject_id',
+        'teacher_id',
+        'room',
+        'period_count',
+        'student_count',
+    ];
+
+    public function subject(): BelongsTo
+    {
+        return $this->belongsTo(Subject::class);
+    }
+
+    public function teacher(): BelongsTo
+    {
+        return $this->belongsTo(Teacher::class);
+    }
+}

--- a/app/Models/CourseOffering.php
+++ b/app/Models/CourseOffering.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CourseOffering extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'subject_id',
+        'semester_id',
+    ];
+
+    public function subject(): BelongsTo
+    {
+        return $this->belongsTo(Subject::class);
+    }
+
+    public function semester(): BelongsTo
+    {
+        return $this->belongsTo(Semester::class);
+    }
+}

--- a/app/Models/Semester.php
+++ b/app/Models/Semester.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\CourseOffering;
 
 class Semester extends Model
 {
@@ -27,5 +28,13 @@ class Semester extends Model
     public function grades(): HasMany
     {
         return $this->hasMany(Grade::class);
+    }
+
+    /**
+     * Các môn học được mở trong học kỳ
+     */
+    public function courseOfferings(): HasMany
+    {
+        return $this->hasMany(CourseOffering::class);
     }
 }

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\CourseOffering;
+use App\Models\ClassSection;
 
 class Subject extends Model
 {
@@ -25,4 +27,20 @@ class Subject extends Model
     {
         return $this->hasMany(Grade::class);
     }
-} 
+
+    /**
+     * Các lần mở môn học trong các học kỳ
+     */
+    public function courseOfferings(): HasMany
+    {
+        return $this->hasMany(CourseOffering::class);
+    }
+
+    /**
+     * Các lớp học phần của môn học
+     */
+    public function classSections(): HasMany
+    {
+        return $this->hasMany(ClassSection::class);
+    }
+}

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\ClassSection;
 
 class Teacher extends Model
 {
@@ -59,4 +61,12 @@ class Teacher extends Model
     {
         return "{$this->first_name} {$this->last_name}";
     }
-} 
+
+    /**
+     * Các lớp học phần do giáo viên giảng dạy
+     */
+    public function classSections(): HasMany
+    {
+        return $this->hasMany(ClassSection::class);
+    }
+}

--- a/database/migrations/2024_03_06_000014_create_course_offerings_table.php
+++ b/database/migrations/2024_03_06_000014_create_course_offerings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('course_offerings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('subject_id')->constrained()->onDelete('cascade');
+            $table->foreignId('semester_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+            $table->unique(['subject_id', 'semester_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('course_offerings');
+    }
+};

--- a/database/migrations/2024_03_06_000015_create_class_sections_table.php
+++ b/database/migrations/2024_03_06_000015_create_class_sections_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('class_sections', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->foreignId('subject_id')->constrained()->onDelete('cascade');
+            $table->foreignId('teacher_id')->constrained()->onDelete('cascade');
+            $table->string('room')->nullable();
+            $table->integer('period_count')->default(0);
+            $table->integer('student_count')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('class_sections');
+    }
+};

--- a/resources/views/class_sections/create.blade.php
+++ b/resources/views/class_sections/create.blade.php
@@ -1,0 +1,98 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ request('auto') ? __('Tạo lớp học phần tự động') : __('Thêm lớp học phần') }}</span>
+                    <a href="{{ route('class-sections.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    @if(request('auto'))
+                        <form method="POST" action="{{ route('class-sections.generate') }}">
+                            @csrf
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Môn học') }} <span class="text-danger">*</span></label>
+                                <select class="form-select" name="subject_id" required>
+                                    <option value="">{{ __('-- Chọn môn học --') }}</option>
+                                    @foreach($subjects as $subject)
+                                        <option value="{{ $subject->id }}">{{ $subject->code }} - {{ $subject->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Giáo viên') }} <span class="text-danger">*</span></label>
+                                <select class="form-select" name="teacher_id" required>
+                                    <option value="">{{ __('-- Chọn giáo viên --') }}</option>
+                                    @foreach($teachers as $teacher)
+                                        <option value="{{ $teacher->id }}">{{ $teacher->full_name }} - {{ $teacher->faculty->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Phòng') }}</label>
+                                <input type="text" class="form-control" name="room" value="{{ old('room') }}">
+                            </div>
+                            <div class="d-grid gap-2">
+                                <button type="submit" class="btn btn-success">
+                                    <i class="fas fa-magic"></i> {{ __('Tạo tự động') }}
+                                </button>
+                            </div>
+                        </form>
+                    @else
+                        <form method="POST" action="{{ route('class-sections.store') }}">
+                            @csrf
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Mã lớp') }} <span class="text-danger">*</span></label>
+                                <input type="text" class="form-control" name="code" value="{{ old('code') }}" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Môn học') }} <span class="text-danger">*</span></label>
+                                <select class="form-select" name="subject_id" required>
+                                    <option value="">{{ __('-- Chọn môn học --') }}</option>
+                                    @foreach($subjects as $subject)
+                                        <option value="{{ $subject->id }}" {{ old('subject_id') == $subject->id ? 'selected' : '' }}>{{ $subject->code }} - {{ $subject->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Giáo viên') }} <span class="text-danger">*</span></label>
+                                <select class="form-select" name="teacher_id" required>
+                                    <option value="">{{ __('-- Chọn giáo viên --') }}</option>
+                                    @foreach($teachers as $teacher)
+                                        <option value="{{ $teacher->id }}" {{ old('teacher_id') == $teacher->id ? 'selected' : '' }}>{{ $teacher->full_name }} - {{ $teacher->faculty->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label class="form-label">{{ __('Phòng') }}</label>
+                                    <input type="text" class="form-control" name="room" value="{{ old('room') }}">
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label">{{ __('Số tiết') }}</label>
+                                    <input type="number" class="form-control" name="period_count" value="{{ old('period_count', 0) }}">
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label">{{ __('Số SV') }}</label>
+                                    <input type="number" class="form-control" name="student_count" value="{{ old('student_count', 0) }}">
+                                </div>
+                            </div>
+                            <div class="d-grid gap-2">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-save"></i> {{ __('Lưu') }}
+                                </button>
+                            </div>
+                        </form>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/class_sections/edit.blade.php
+++ b/resources/views/class_sections/edit.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Chỉnh sửa lớp học phần') }}</span>
+                    <a href="{{ route('class-sections.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('class-sections.update', $classSection->id) }}">
+                        @csrf
+                        @method('PUT')
+                        <div class="mb-3">
+                            <label class="form-label">{{ __('Mã lớp') }} <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" name="code" value="{{ old('code', $classSection->code) }}" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">{{ __('Môn học') }} <span class="text-danger">*</span></label>
+                            <select class="form-select" name="subject_id" required>
+                                @foreach($subjects as $subject)
+                                    <option value="{{ $subject->id }}" {{ $classSection->subject_id == $subject->id ? 'selected' : '' }}>{{ $subject->code }} - {{ $subject->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">{{ __('Giáo viên') }} <span class="text-danger">*</span></label>
+                            <select class="form-select" name="teacher_id" required>
+                                @foreach($teachers as $teacher)
+                                    <option value="{{ $teacher->id }}" {{ $classSection->teacher_id == $teacher->id ? 'selected' : '' }}>{{ $teacher->full_name }} - {{ $teacher->faculty->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-md-6">
+                                <label class="form-label">{{ __('Phòng') }}</label>
+                                <input type="text" class="form-control" name="room" value="{{ old('room', $classSection->room) }}">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">{{ __('Số tiết') }}</label>
+                                <input type="number" class="form-control" name="period_count" value="{{ old('period_count', $classSection->period_count) }}">
+                            </div>
+                            <div class="col-md-3">
+                                <label class="form-label">{{ __('Số SV') }}</label>
+                                <input type="number" class="form-control" name="student_count" value="{{ old('student_count', $classSection->student_count) }}">
+                            </div>
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Lưu') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/class_sections/index.blade.php
+++ b/resources/views/class_sections/index.blade.php
@@ -1,0 +1,72 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Danh sách lớp học phần') }}</span>
+                    <div>
+                        <a href="{{ route('class-sections.create') }}" class="btn btn-primary btn-sm me-1">
+                            <i class="fas fa-plus"></i> {{ __('Thêm') }}
+                        </a>
+                        <a href="{{ route('class-sections.create', ['auto' => 1]) }}" class="btn btn-success btn-sm">
+                            <i class="fas fa-magic"></i> {{ __('Tạo tự động') }}
+                        </a>
+                    </div>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover">
+                            <thead class="table-light">
+                                <tr>
+                                    <th width="5%">{{ __('STT') }}</th>
+                                    <th>{{ __('Mã lớp') }}</th>
+                                    <th>{{ __('Môn học') }}</th>
+                                    <th>{{ __('Giáo viên') }}</th>
+                                    <th>{{ __('Phòng') }}</th>
+                                    <th>{{ __('Số tiết') }}</th>
+                                    <th>{{ __('Số SV') }}</th>
+                                    <th width="15%">{{ __('Thao tác') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($sections as $key => $section)
+                                <tr>
+                                    <td>{{ $sections->firstItem() + $key }}</td>
+                                    <td>{{ $section->code }}</td>
+                                    <td>{{ $section->subject->code }} - {{ $section->subject->name }}</td>
+                                    <td>{{ $section->teacher->full_name }} - {{ $section->teacher->faculty->name }}</td>
+                                    <td>{{ $section->room }}</td>
+                                    <td>{{ $section->period_count }}</td>
+                                    <td>{{ $section->student_count }}</td>
+                                    <td>
+                                        <div class="d-flex">
+                                            <a href="{{ route('class-sections.edit', $section->id) }}" class="btn btn-sm btn-info me-1">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                            <form action="{{ route('class-sections.destroy', $section->id) }}" method="POST" onsubmit="return confirm('{{ __('Xóa?') }}')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-danger">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-center mt-3">
+                        {{ $sections->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/course_offerings/create.blade.php
+++ b/resources/views/course_offerings/create.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Thêm mở môn học') }}</span>
+                    <a href="{{ route('course-offerings.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('course-offerings.store') }}">
+                        @csrf
+                        <div class="mb-3">
+                            <label for="subject_id" class="form-label">{{ __('Môn học') }} <span class="text-danger">*</span></label>
+                            <select class="form-select" id="subject_id" name="subject_id" required>
+                                <option value="">{{ __('-- Chọn môn học --') }}</option>
+                                @foreach($subjects as $subject)
+                                    <option value="{{ $subject->id }}" {{ old('subject_id') == $subject->id ? 'selected' : '' }}>{{ $subject->code }} - {{ $subject->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="semester_id" class="form-label">{{ __('Học kỳ') }} <span class="text-danger">*</span></label>
+                            <select class="form-select" id="semester_id" name="semester_id" required>
+                                <option value="">{{ __('-- Chọn học kỳ --') }}</option>
+                                @foreach($semesters as $semester)
+                                    <option value="{{ $semester->id }}" {{ old('semester_id') == $semester->id ? 'selected' : '' }}>{{ $semester->name }} ({{ $semester->academicYear->name }})</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Lưu') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/course_offerings/edit.blade.php
+++ b/resources/views/course_offerings/edit.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Chỉnh sửa mở môn học') }}</span>
+                    <a href="{{ route('course-offerings.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('course-offerings.update', $courseOffering->id) }}">
+                        @csrf
+                        @method('PUT')
+                        <div class="mb-3">
+                            <label for="subject_id" class="form-label">{{ __('Môn học') }} <span class="text-danger">*</span></label>
+                            <select class="form-select" id="subject_id" name="subject_id" required>
+                                @foreach($subjects as $subject)
+                                    <option value="{{ $subject->id }}" {{ $courseOffering->subject_id == $subject->id ? 'selected' : '' }}>{{ $subject->code }} - {{ $subject->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="semester_id" class="form-label">{{ __('Học kỳ') }} <span class="text-danger">*</span></label>
+                            <select class="form-select" id="semester_id" name="semester_id" required>
+                                @foreach($semesters as $semester)
+                                    <option value="{{ $semester->id }}" {{ $courseOffering->semester_id == $semester->id ? 'selected' : '' }}>{{ $semester->name }} ({{ $semester->academicYear->name }})</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Lưu') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/course_offerings/index.blade.php
+++ b/resources/views/course_offerings/index.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Danh sách mở môn học') }}</span>
+                    <a href="{{ route('course-offerings.create') }}" class="btn btn-primary btn-sm">
+                        <i class="fas fa-plus"></i> {{ __('Thêm') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover">
+                            <thead class="table-light">
+                                <tr>
+                                    <th width="5%">{{ __('STT') }}</th>
+                                    <th>{{ __('Môn học') }}</th>
+                                    <th>{{ __('Học kỳ') }}</th>
+                                    <th width="15%">{{ __('Thao tác') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($courseOfferings as $key => $offering)
+                                <tr>
+                                    <td>{{ $courseOfferings->firstItem() + $key }}</td>
+                                    <td>{{ $offering->subject->code }} - {{ $offering->subject->name }}</td>
+                                    <td>{{ $offering->semester->name }} ({{ $offering->semester->academicYear->name }})</td>
+                                    <td>
+                                        <div class="d-flex">
+                                            <a href="{{ route('course-offerings.edit', $offering->id) }}" class="btn btn-sm btn-info me-1">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                            <form action="{{ route('course-offerings.destroy', $offering->id) }}" method="POST" onsubmit="return confirm('{{ __('Xóa?') }}')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-danger">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-center mt-3">
+                        {{ $courseOfferings->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -231,6 +231,18 @@
                                         <i class="fas fa-book-open"></i> Quản lý môn học
                                     </a>
                                 </li>
+
+                                <li class="nav-item">
+                                    <a class="nav-link {{ request()->routeIs('course-offerings.*') ? 'active' : '' }}" href="{{ route('course-offerings.index') }}">
+                                        <i class="fas fa-calendar-alt"></i> Mở môn học
+                                    </a>
+                                </li>
+
+                                <li class="nav-item">
+                                    <a class="nav-link {{ request()->routeIs('class-sections.*') ? 'active' : '' }}" href="{{ route('class-sections.index') }}">
+                                        <i class="fas fa-list"></i> Lớp học phần
+                                    </a>
+                                </li>
                                 
                                 <li class="nav-item">
                                     <a class="nav-link {{ request()->routeIs('teachers.*') ? 'active' : '' }}" href="{{ route('teachers.index') }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\MajorController;
 use App\Http\Controllers\StudentController;
 use App\Http\Controllers\SubjectController;
 use App\Http\Controllers\TeacherController;
+use App\Http\Controllers\CourseOfferingController;
+use App\Http\Controllers\ClassSectionController;
 use App\Http\Controllers\DegreeController;
 use App\Http\Controllers\AcademicYearController;
 use App\Http\Controllers\SemesterController;
@@ -64,6 +66,13 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 
     // Quản lý giáo viên
     Route::resource('teachers', TeacherController::class);
+
+    // Mở môn học
+    Route::resource('course-offerings', CourseOfferingController::class);
+
+    // Lớp học phần
+    Route::post('class-sections/generate', [ClassSectionController::class, 'generate'])->name('class-sections.generate');
+    Route::resource('class-sections', ClassSectionController::class);
 });
 
 // Nhóm route yêu cầu xác thực và quyền admin hoặc giáo viên


### PR DESCRIPTION
## Summary
- add CourseOffering & ClassSection models/migrations
- implement CRUD controllers
- add pages for managing course offerings and class sections
- show teacher dropdown with faculty info
- wire up admin routes and navigation

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c7cdd501083259bd2d6c9468e84c9