### PR TITLE
Add teaching payment coefficients and calculation service

### DIFF
--- a/app/Http/Controllers/ClassSizeCoefficientController.php
+++ b/app/Http/Controllers/ClassSizeCoefficientController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ClassSizeCoefficient;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class ClassSizeCoefficientController extends Controller
+{
+    public function index()
+    {
+        $coefficients = ClassSizeCoefficient::paginate(10);
+        return view('class_size_coefficients.index', compact('coefficients'));
+    }
+
+    public function create()
+    {
+        return view('class_size_coefficients.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'min_students' => 'required|integer',
+            'max_students' => 'required|integer|gte:min_students',
+            'coefficient' => 'required|numeric',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        ClassSizeCoefficient::create($request->all());
+
+        return redirect()->route('class-size-coefficients.index')
+            ->with('success', 'Hệ số sĩ số đã được tạo.');
+    }
+
+    public function edit(ClassSizeCoefficient $classSizeCoefficient)
+    {
+        return view('class_size_coefficients.edit', compact('classSizeCoefficient'));
+    }
+
+    public function update(Request $request, ClassSizeCoefficient $classSizeCoefficient)
+    {
+        $validator = Validator::make($request->all(), [
+            'min_students' => 'required|integer',
+            'max_students' => 'required|integer|gte:min_students',
+            'coefficient' => 'required|numeric',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $classSizeCoefficient->update($request->all());
+
+        return redirect()->route('class-size-coefficients.index')
+            ->with('success', 'Hệ số sĩ số đã được cập nhật.');
+    }
+
+    public function destroy(ClassSizeCoefficient $classSizeCoefficient)
+    {
+        $classSizeCoefficient->delete();
+
+        return redirect()->route('class-size-coefficients.index')
+            ->with('success', 'Hệ số sĩ số đã được xóa.');
+    }
+}

--- a/app/Http/Controllers/DegreeCoefficientController.php
+++ b/app/Http/Controllers/DegreeCoefficientController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DegreeCoefficient;
+use App\Models\Degree;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class DegreeCoefficientController extends Controller
+{
+    public function index()
+    {
+        $coefficients = DegreeCoefficient::with('degree')->paginate(10);
+        return view('degree_coefficients.index', compact('coefficients'));
+    }
+
+    public function create()
+    {
+        $degrees = Degree::all();
+        return view('degree_coefficients.create', compact('degrees'));
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'degree_id' => 'required|exists:degrees,id',
+            'coefficient' => 'required|numeric',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        DegreeCoefficient::updateOrCreate(
+            ['degree_id' => $request->degree_id],
+            ['coefficient' => $request->coefficient]
+        );
+
+        return redirect()->route('degree-coefficients.index')
+            ->with('success', 'Hệ số học vị đã được lưu.');
+    }
+
+    public function edit(DegreeCoefficient $degreeCoefficient)
+    {
+        $degrees = Degree::all();
+        return view('degree_coefficients.edit', compact('degreeCoefficient', 'degrees'));
+    }
+
+    public function update(Request $request, DegreeCoefficient $degreeCoefficient)
+    {
+        $validator = Validator::make($request->all(), [
+            'degree_id' => 'required|exists:degrees,id',
+            'coefficient' => 'required|numeric',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $degreeCoefficient->update($request->all());
+
+        return redirect()->route('degree-coefficients.index')
+            ->with('success', 'Hệ số học vị đã được cập nhật.');
+    }
+
+    public function destroy(DegreeCoefficient $degreeCoefficient)
+    {
+        $degreeCoefficient->delete();
+
+        return redirect()->route('degree-coefficients.index')
+            ->with('success', 'Hệ số học vị đã được xóa.');
+    }
+}

--- a/app/Http/Controllers/TeachingRateController.php
+++ b/app/Http/Controllers/TeachingRateController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TeachingRate;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class TeachingRateController extends Controller
+{
+    public function index()
+    {
+        $rates = TeachingRate::paginate(10);
+        return view('teaching_rates.index', compact('rates'));
+    }
+
+    public function create()
+    {
+        return view('teaching_rates.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'amount' => 'required|numeric',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        TeachingRate::create($request->all());
+
+        return redirect()->route('teaching-rates.index')
+            ->with('success', 'Mức lương đã được tạo thành công.');
+    }
+
+    public function edit(TeachingRate $teachingRate)
+    {
+        return view('teaching_rates.edit', compact('teachingRate'));
+    }
+
+    public function update(Request $request, TeachingRate $teachingRate)
+    {
+        $validator = Validator::make($request->all(), [
+            'amount' => 'required|numeric',
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        $teachingRate->update($request->all());
+
+        return redirect()->route('teaching-rates.index')
+            ->with('success', 'Mức lương đã được cập nhật thành công.');
+    }
+
+    public function destroy(TeachingRate $teachingRate)
+    {
+        $teachingRate->delete();
+
+        return redirect()->route('teaching-rates.index')
+            ->with('success', 'Mức lương đã được xóa thành công.');
+    }
+}

--- a/app/Models/ClassSizeCoefficient.php
+++ b/app/Models/ClassSizeCoefficient.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ClassSizeCoefficient extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'min_students',
+        'max_students',
+        'coefficient',
+    ];
+}

--- a/app/Models/DegreeCoefficient.php
+++ b/app/Models/DegreeCoefficient.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DegreeCoefficient extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['degree_id', 'coefficient'];
+
+    public function degree(): BelongsTo
+    {
+        return $this->belongsTo(Degree::class);
+    }
+}

--- a/app/Models/TeachingRate.php
+++ b/app/Models/TeachingRate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeachingRate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['amount'];
+}

--- a/app/Services/TeachingPaymentService.php
+++ b/app/Services/TeachingPaymentService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TeachingRate;
+use App\Models\DegreeCoefficient;
+use App\Models\ClassSizeCoefficient;
+use App\Models\Teacher;
+use App\Models\Subject;
+
+class TeachingPaymentService
+{
+    public function calculate(Teacher $teacher, Subject $subject, int $studentCount, int $periods): float
+    {
+        $base = TeachingRate::orderByDesc('id')->value('amount') ?? 0;
+
+        $degreeCoefficient = DegreeCoefficient::where('degree_id', $teacher->degree_id)
+            ->value('coefficient') ?? 1;
+
+        $classCoefficient = ClassSizeCoefficient::where('min_students', '<=', $studentCount)
+            ->where('max_students', '>=', $studentCount)
+            ->value('coefficient') ?? 1;
+
+        $difficulty = $subject->difficulty_ratio ?? 1;
+
+        return $base * $degreeCoefficient * $classCoefficient * $difficulty * $periods;
+    }
+}

--- a/database/migrations/2024_03_06_000014_create_teaching_rates_table.php
+++ b/database/migrations/2024_03_06_000014_create_teaching_rates_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teaching_rates', function (Blueprint $table) {
+            $table->id();
+            $table->decimal('amount', 12, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teaching_rates');
+    }
+};

--- a/database/migrations/2024_03_06_000015_create_degree_coefficients_table.php
+++ b/database/migrations/2024_03_06_000015_create_degree_coefficients_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('degree_coefficients', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('degree_id')->constrained()->onDelete('cascade');
+            $table->decimal('coefficient', 5, 2);
+            $table->timestamps();
+            $table->unique('degree_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('degree_coefficients');
+    }
+};

--- a/database/migrations/2024_03_06_000016_create_class_size_coefficients_table.php
+++ b/database/migrations/2024_03_06_000016_create_class_size_coefficients_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('class_size_coefficients', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('min_students');
+            $table->unsignedInteger('max_students');
+            $table->decimal('coefficient', 5, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('class_size_coefficients');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/resources/views/class_size_coefficients/create.blade.php
+++ b/resources/views/class_size_coefficients/create.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Thêm hệ số sĩ số') }}</span>
+                    <a href="{{ route('class-size-coefficients.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('class-size-coefficients.store') }}">
+                        @csrf
+                        <div class="mb-3">
+                            <label for="min_students" class="form-label">{{ __('Sĩ số từ') }}</label>
+                            <input type="number" name="min_students" id="min_students" class="form-control @error('min_students') is-invalid @enderror" value="{{ old('min_students') }}" required>
+                            @error('min_students')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="max_students" class="form-label">{{ __('Đến') }}</label>
+                            <input type="number" name="max_students" id="max_students" class="form-control @error('max_students') is-invalid @enderror" value="{{ old('max_students') }}" required>
+                            @error('max_students')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="coefficient" class="form-label">{{ __('Hệ số') }}</label>
+                            <input type="number" step="0.01" name="coefficient" id="coefficient" class="form-control @error('coefficient') is-invalid @enderror" value="{{ old('coefficient') }}" required>
+                            @error('coefficient')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Lưu') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/class_size_coefficients/edit.blade.php
+++ b/resources/views/class_size_coefficients/edit.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Chỉnh sửa hệ số sĩ số') }}</span>
+                    <a href="{{ route('class-size-coefficients.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('class-size-coefficients.update', $classSizeCoefficient->id) }}">
+                        @csrf
+                        @method('PUT')
+                        <div class="mb-3">
+                            <label for="min_students" class="form-label">{{ __('Sĩ số từ') }}</label>
+                            <input type="number" name="min_students" id="min_students" class="form-control @error('min_students') is-invalid @enderror" value="{{ old('min_students', $classSizeCoefficient->min_students) }}" required>
+                            @error('min_students')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="max_students" class="form-label">{{ __('Đến') }}</label>
+                            <input type="number" name="max_students" id="max_students" class="form-control @error('max_students') is-invalid @enderror" value="{{ old('max_students', $classSizeCoefficient->max_students) }}" required>
+                            @error('max_students')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="coefficient" class="form-label">{{ __('Hệ số') }}</label>
+                            <input type="number" step="0.01" name="coefficient" id="coefficient" class="form-control @error('coefficient') is-invalid @enderror" value="{{ old('coefficient', $classSizeCoefficient->coefficient) }}" required>
+                            @error('coefficient')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Cập nhật') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/class_size_coefficients/index.blade.php
+++ b/resources/views/class_size_coefficients/index.blade.php
@@ -1,0 +1,65 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-10">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Hệ số sĩ số') }}</span>
+                    <a href="{{ route('class-size-coefficients.create') }}" class="btn btn-primary btn-sm">
+                        <i class="fas fa-plus"></i> {{ __('Thêm mới') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover">
+                            <thead class="table-light">
+                                <tr>
+                                    <th width="5%">#</th>
+                                    <th>{{ __('Sĩ số từ') }}</th>
+                                    <th>{{ __('Đến') }}</th>
+                                    <th>{{ __('Hệ số') }}</th>
+                                    <th width="20%">{{ __('Thao tác') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($coefficients as $key => $coef)
+                                <tr>
+                                    <td>{{ $coefficients->firstItem() + $key }}</td>
+                                    <td>{{ $coef->min_students }}</td>
+                                    <td>{{ $coef->max_students }}</td>
+                                    <td>{{ $coef->coefficient }}</td>
+                                    <td>
+                                        <div class="d-flex">
+                                            <a href="{{ route('class-size-coefficients.edit', $coef->id) }}" class="btn btn-sm btn-info me-1">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                            <form action="{{ route('class-size-coefficients.destroy', $coef->id) }}" method="POST" onsubmit="return confirm('{{ __('Bạn có chắc chắn?') }}')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-danger">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                                @empty
+                                <tr>
+                                    <td colspan="5" class="text-center">{{ __('Không có dữ liệu') }}</td>
+                                </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-center mt-3">
+                        {{ $coefficients->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/degree_coefficients/create.blade.php
+++ b/resources/views/degree_coefficients/create.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Thêm hệ số học vị') }}</span>
+                    <a href="{{ route('degree-coefficients.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('degree-coefficients.store') }}">
+                        @csrf
+                        <div class="mb-3">
+                            <label for="degree_id" class="form-label">{{ __('Học vị') }}</label>
+                            <select name="degree_id" id="degree_id" class="form-select @error('degree_id') is-invalid @enderror" required>
+                                <option value="">-- {{ __('Chọn') }} --</option>
+                                @foreach($degrees as $degree)
+                                    <option value="{{ $degree->id }}" {{ old('degree_id') == $degree->id ? 'selected' : '' }}>{{ $degree->name }}</option>
+                                @endforeach
+                            </select>
+                            @error('degree_id')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="coefficient" class="form-label">{{ __('Hệ số') }}</label>
+                            <input type="number" step="0.01" name="coefficient" id="coefficient" class="form-control @error('coefficient') is-invalid @enderror" value="{{ old('coefficient') }}" required>
+                            @error('coefficient')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Lưu') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/degree_coefficients/edit.blade.php
+++ b/resources/views/degree_coefficients/edit.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Chỉnh sửa hệ số học vị') }}</span>
+                    <a href="{{ route('degree-coefficients.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('degree-coefficients.update', $degreeCoefficient->id) }}">
+                        @csrf
+                        @method('PUT')
+                        <div class="mb-3">
+                            <label for="degree_id" class="form-label">{{ __('Học vị') }}</label>
+                            <select name="degree_id" id="degree_id" class="form-select @error('degree_id') is-invalid @enderror" required>
+                                <option value="">-- {{ __('Chọn') }} --</option>
+                                @foreach($degrees as $degree)
+                                    <option value="{{ $degree->id }}" {{ old('degree_id', $degreeCoefficient->degree_id) == $degree->id ? 'selected' : '' }}>{{ $degree->name }}</option>
+                                @endforeach
+                            </select>
+                            @error('degree_id')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="coefficient" class="form-label">{{ __('Hệ số') }}</label>
+                            <input type="number" step="0.01" name="coefficient" id="coefficient" class="form-control @error('coefficient') is-invalid @enderror" value="{{ old('coefficient', $degreeCoefficient->coefficient) }}" required>
+                            @error('coefficient')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Cập nhật') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/degree_coefficients/index.blade.php
+++ b/resources/views/degree_coefficients/index.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-10">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Hệ số học vị') }}</span>
+                    <a href="{{ route('degree-coefficients.create') }}" class="btn btn-primary btn-sm">
+                        <i class="fas fa-plus"></i> {{ __('Thêm mới') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover">
+                            <thead class="table-light">
+                                <tr>
+                                    <th width="5%">#</th>
+                                    <th>{{ __('Học vị') }}</th>
+                                    <th>{{ __('Hệ số') }}</th>
+                                    <th width="20%">{{ __('Thao tác') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($coefficients as $key => $coef)
+                                <tr>
+                                    <td>{{ $coefficients->firstItem() + $key }}</td>
+                                    <td>{{ $coef->degree->name }}</td>
+                                    <td>{{ $coef->coefficient }}</td>
+                                    <td>
+                                        <div class="d-flex">
+                                            <a href="{{ route('degree-coefficients.edit', $coef->id) }}" class="btn btn-sm btn-info me-1">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                            <form action="{{ route('degree-coefficients.destroy', $coef->id) }}" method="POST" onsubmit="return confirm('{{ __('Bạn có chắc chắn?') }}')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-danger">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                                @empty
+                                <tr>
+                                    <td colspan="4" class="text-center">{{ __('Không có dữ liệu') }}</td>
+                                </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-center mt-3">
+                        {{ $coefficients->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/teaching_rates/create.blade.php
+++ b/resources/views/teaching_rates/create.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Thêm mức lương') }}</span>
+                    <a href="{{ route('teaching-rates.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('teaching-rates.store') }}">
+                        @csrf
+                        <div class="mb-3">
+                            <label for="amount" class="form-label">{{ __('Số tiền mỗi tiết') }} <span class="text-danger">*</span></label>
+                            <input type="number" step="0.01" class="form-control @error('amount') is-invalid @enderror" name="amount" id="amount" value="{{ old('amount') }}" required>
+                            @error('amount')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Lưu') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/teaching_rates/edit.blade.php
+++ b/resources/views/teaching_rates/edit.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Chỉnh sửa mức lương') }}</span>
+                    <a href="{{ route('teaching-rates.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> {{ __('Quay lại') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <form method="POST" action="{{ route('teaching-rates.update', $teachingRate->id) }}">
+                        @csrf
+                        @method('PUT')
+                        <div class="mb-3">
+                            <label for="amount" class="form-label">{{ __('Số tiền mỗi tiết') }} <span class="text-danger">*</span></label>
+                            <input type="number" step="0.01" class="form-control @error('amount') is-invalid @enderror" name="amount" id="amount" value="{{ old('amount', $teachingRate->amount) }}" required>
+                            @error('amount')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i> {{ __('Cập nhật') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/teaching_rates/index.blade.php
+++ b/resources/views/teaching_rates/index.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-10">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>{{ __('Danh sách mức lương') }}</span>
+                    <a href="{{ route('teaching-rates.create') }}" class="btn btn-primary btn-sm">
+                        <i class="fas fa-plus"></i> {{ __('Thêm mới') }}
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover">
+                            <thead class="table-light">
+                                <tr>
+                                    <th width="5%">#</th>
+                                    <th>{{ __('Số tiền mỗi tiết') }}</th>
+                                    <th width="20%">{{ __('Thao tác') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($rates as $key => $rate)
+                                <tr>
+                                    <td>{{ $rates->firstItem() + $key }}</td>
+                                    <td>{{ $rate->amount }}</td>
+                                    <td>
+                                        <div class="d-flex">
+                                            <a href="{{ route('teaching-rates.edit', $rate->id) }}" class="btn btn-sm btn-info me-1">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                            <form action="{{ route('teaching-rates.destroy', $rate->id) }}" method="POST" onsubmit="return confirm('{{ __('Bạn có chắc chắn?') }}')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-danger">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                                @empty
+                                <tr>
+                                    <td colspan="3" class="text-center">{{ __('Không có dữ liệu') }}</td>
+                                </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-center mt-3">
+                        {{ $rates->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,9 @@ use App\Http\Controllers\StudentController;
 use App\Http\Controllers\SubjectController;
 use App\Http\Controllers\TeacherController;
 use App\Http\Controllers\DegreeController;
+use App\Http\Controllers\TeachingRateController;
+use App\Http\Controllers\DegreeCoefficientController;
+use App\Http\Controllers\ClassSizeCoefficientController;
 use App\Http\Controllers\AcademicYearController;
 use App\Http\Controllers\SemesterController;
 use Illuminate\Support\Facades\Route;
@@ -64,6 +67,11 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 
     // Quản lý giáo viên
     Route::resource('teachers', TeacherController::class);
+
+    // Quản lý hệ số và mức lương giảng dạy
+    Route::resource('teaching-rates', TeachingRateController::class);
+    Route::resource('degree-coefficients', DegreeCoefficientController::class);
+    Route::resource('class-size-coefficients', ClassSizeCoefficientController::class);
 });
 
 // Nhóm route yêu cầu xác thực và quyền admin hoặc giáo viên

--- a/tests/Unit/TeachingPaymentServiceTest.php
+++ b/tests/Unit/TeachingPaymentServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Subject;
+use App\Models\Teacher;
+use App\Models\TeachingRate;
+use App\Models\DegreeCoefficient;
+use App\Models\ClassSizeCoefficient;
+use App\Services\TeachingPaymentService;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class TeachingPaymentServiceTest extends TestCase
+{
+    use RefreshDatabase;
+    public function test_calculate_payment()
+    {
+        $teacher = new Teacher(['degree_id' => 1]);
+        $subject = new Subject(['difficulty_ratio' => 1.2]);
+
+        TeachingRate::unguard();
+        TeachingRate::create(['id' => 1, 'amount' => 100]);
+
+        DegreeCoefficient::unguard();
+        DegreeCoefficient::create(['degree_id' => 1, 'coefficient' => 1.5]);
+
+        ClassSizeCoefficient::unguard();
+        ClassSizeCoefficient::create(['min_students' => 1, 'max_students' => 50, 'coefficient' => 1.1]);
+
+        $service = new TeachingPaymentService();
+        $payment = $service->calculate($teacher, $subject, 30, 10);
+
+        $this->assertEquals(100 * 1.5 * 1.1 * 1.2 * 10, $payment);
+    }
+}


### PR DESCRIPTION
## Summary
- add tables for teaching rates, degree coefficients, class size coefficients
- expose CRUD controllers and routes for managing coefficients
- create basic views for admin UI
- implement `TeachingPaymentService` for class section pay calculations
- provide PHPUnit test verifying payment formula

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c7e2b49c48325bc7545da6b244d55