### PR TITLE
Add faculty to subjects

### DIFF
--- a/app/Http/Controllers/CourseOfferingController.php
+++ b/app/Http/Controllers/CourseOfferingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\CourseOffering;
 use App\Models\Subject;
 use App\Models\Semester;
+use App\Models\Faculty;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
@@ -16,11 +17,16 @@ class CourseOfferingController extends Controller
         return view('course_offerings.index', compact('courseOfferings'));
     }
 
-    public function create()
+    public function create(Request $request)
     {
-        $subjects = Subject::all();
+        $subjectsQuery = Subject::query();
+        if ($request->has('faculty_id') && $request->faculty_id) {
+            $subjectsQuery->where('faculty_id', $request->faculty_id);
+        }
+        $subjects = $subjectsQuery->get();
         $semesters = Semester::with('academicYear')->get();
-        return view('course_offerings.create', compact('subjects', 'semesters'));
+        $faculties = Faculty::all();
+        return view('course_offerings.create', compact('subjects', 'semesters', 'faculties'));
     }
 
     public function store(Request $request)
@@ -36,11 +42,16 @@ class CourseOfferingController extends Controller
         return redirect()->route('course-offerings.index')->with('success', 'Đã lưu thông tin.');
     }
 
-    public function edit(CourseOffering $courseOffering)
+    public function edit(CourseOffering $courseOffering, Request $request)
     {
-        $subjects = Subject::all();
+        $subjectsQuery = Subject::query();
+        if ($request->has('faculty_id') && $request->faculty_id) {
+            $subjectsQuery->where('faculty_id', $request->faculty_id);
+        }
+        $subjects = $subjectsQuery->get();
         $semesters = Semester::with('academicYear')->get();
-        return view('course_offerings.edit', compact('courseOffering', 'subjects', 'semesters'));
+        $faculties = Faculty::all();
+        return view('course_offerings.edit', compact('courseOffering', 'subjects', 'semesters', 'faculties'));
     }
 
     public function update(Request $request, CourseOffering $courseOffering)

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Subject;
+use App\Models\Faculty;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
@@ -13,7 +14,11 @@ class SubjectController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Subject::query();
+        $query = Subject::with('faculty');
+
+        if ($request->has('faculty_id') && $request->faculty_id) {
+            $query->where('faculty_id', $request->faculty_id);
+        }
         
         // Tìm kiếm theo tên hoặc mã môn học
         if ($request->has('search') && $request->search) {
@@ -31,8 +36,9 @@ class SubjectController extends Controller
         
         $subjects = $query->paginate(10);
         $creditOptions = Subject::distinct()->orderBy('credits')->pluck('credits');
-        
-        return view('subjects.index', compact('subjects', 'creditOptions'));
+        $faculties = Faculty::all();
+
+        return view('subjects.index', compact('subjects', 'creditOptions', 'faculties'));
     }
 
     /**
@@ -40,7 +46,8 @@ class SubjectController extends Controller
      */
     public function create()
     {
-        return view('subjects.create');
+        $faculties = Faculty::all();
+        return view('subjects.create', compact('faculties'));
     }
 
     /**
@@ -54,6 +61,7 @@ class SubjectController extends Controller
             'credits' => 'required|integer|min:1|max:10',
             'description' => 'nullable|string',
             'difficulty_ratio' => 'nullable|numeric',
+            'faculty_id' => 'required|exists:faculties,id',
         ]);
 
         if ($validator->fails()) {
@@ -82,7 +90,8 @@ class SubjectController extends Controller
      */
     public function edit(Subject $subject)
     {
-        return view('subjects.edit', compact('subject'));
+        $faculties = Faculty::all();
+        return view('subjects.edit', compact('subject', 'faculties'));
     }
 
     /**
@@ -96,6 +105,7 @@ class SubjectController extends Controller
             'credits' => 'required|integer|min:1|max:10',
             'description' => 'nullable|string',
             'difficulty_ratio' => 'nullable|numeric',
+            'faculty_id' => 'required|exists:faculties,id',
         ]);
 
         if ($validator->fails()) {

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -5,8 +5,10 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use App\Models\CourseOffering;
 use App\Models\ClassSection;
+use App\Models\Faculty;
 
 class Subject extends Model
 {
@@ -18,6 +20,7 @@ class Subject extends Model
         'credits',
         'description',
         'difficulty_ratio',
+        'faculty_id',
     ];
 
     /**
@@ -42,5 +45,13 @@ class Subject extends Model
     public function classSections(): HasMany
     {
         return $this->hasMany(ClassSection::class);
+    }
+
+    /**
+     * Khoa quản lý môn học
+     */
+    public function faculty(): BelongsTo
+    {
+        return $this->belongsTo(Faculty::class);
     }
 }

--- a/database/migrations/2025_06_14_044201_add_faculty_id_to_subjects_table.php
+++ b/database/migrations/2025_06_14_044201_add_faculty_id_to_subjects_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            $table->foreignId('faculty_id')->nullable()->after('difficulty_ratio')->constrained();
+        });
+
+        $facultyId = DB::table('faculties')->value('id');
+        if ($facultyId) {
+            DB::table('subjects')->whereNull('faculty_id')->update(['faculty_id' => $facultyId]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('faculty_id');
+        });
+    }
+};

--- a/resources/views/subjects/create.blade.php
+++ b/resources/views/subjects/create.blade.php
@@ -19,6 +19,19 @@
                         @csrf
 
                         <div class="mb-3">
+                            <label for="faculty_id" class="form-label">{{ __('Khoa') }} <span class="text-danger">*</span></label>
+                            <select class="form-select @error('faculty_id') is-invalid @enderror" id="faculty_id" name="faculty_id" required>
+                                <option value="">{{ __('-- Chọn khoa --') }}</option>
+                                @foreach($faculties as $faculty)
+                                    <option value="{{ $faculty->id }}" {{ old('faculty_id') == $faculty->id ? 'selected' : '' }}>{{ $faculty->name }}</option>
+                                @endforeach
+                            </select>
+                            @error('faculty_id')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="mb-3">
                             <label for="name" class="form-label">{{ __('Tên môn học') }} <span class="text-danger">*</span></label>
                             <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name') }}" required>
                             @error('name')

--- a/resources/views/subjects/edit.blade.php
+++ b/resources/views/subjects/edit.blade.php
@@ -20,6 +20,19 @@
                         @method('PUT')
 
                         <div class="mb-3">
+                            <label for="faculty_id" class="form-label">{{ __('Khoa') }} <span class="text-danger">*</span></label>
+                            <select class="form-select @error('faculty_id') is-invalid @enderror" id="faculty_id" name="faculty_id" required>
+                                <option value="">{{ __('-- Chọn khoa --') }}</option>
+                                @foreach($faculties as $faculty)
+                                    <option value="{{ $faculty->id }}" {{ old('faculty_id', $subject->faculty_id) == $faculty->id ? 'selected' : '' }}>{{ $faculty->name }}</option>
+                                @endforeach
+                            </select>
+                            @error('faculty_id')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="mb-3">
                             <label for="name" class="form-label">{{ __('Tên môn học') }} <span class="text-danger">*</span></label>
                             <input type="text" class="form-control @error('name') is-invalid @enderror" id="name" name="name" value="{{ old('name', $subject->name) }}" required>
                             @error('name')

--- a/resources/views/subjects/index.blade.php
+++ b/resources/views/subjects/index.blade.php
@@ -29,7 +29,15 @@
                                     @endforeach
                                 </select>
                             </div>
-                            <div class="col-md-7">
+                            <div class="col-md-3">
+                                <select name="faculty_id" class="form-select">
+                                    <option value="">{{ __('-- Tất cả khoa --') }}</option>
+                                    @foreach($faculties as $faculty)
+                                        <option value="{{ $faculty->id }}" {{ request('faculty_id') == $faculty->id ? 'selected' : '' }}>{{ $faculty->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="col-md-5">
                                 <div class="input-group">
                                     <input type="text" name="search" class="form-control" placeholder="{{ __('Tìm kiếm theo tên hoặc mã môn học...') }}" value="{{ request('search') }}">
                                     <button class="btn btn-outline-secondary" type="submit">
@@ -37,7 +45,7 @@
                                     </button>
                                 </div>
                             </div>
-                            <div class="col-md-2">
+                            <div class="col-md-1">
                                 <a href="{{ route('subjects.index') }}" class="btn btn-outline-secondary w-100">
                                     <i class="fas fa-redo"></i> {{ __('Làm mới') }}
                                 </a>
@@ -54,6 +62,7 @@
                                     <th width="35%">{{ __('Tên môn học') }}</th>
                                     <th width="10%">{{ __('Số tín chỉ') }}</th>
                                     <th width="10%">{{ __('Độ khó') }}</th>
+                                    <th width="20%">{{ __('Khoa') }}</th>
                                     <th width="20%">{{ __('Mô tả') }}</th>
                                     @if(auth()->user()->role == 'admin')
                                     <th width="15%">{{ __('Thao tác') }}</th>
@@ -68,6 +77,7 @@
                                    <td>{{ $subject->name }}</td>
                                    <td>{{ $subject->credits }}</td>
                                    <td>{{ $subject->difficulty_ratio }}</td>
+                                   <td>{{ $subject->faculty->name ?? '' }}</td>
                                    <td>{{ Str::limit($subject->description, 50) }}</td>
                                     @if(auth()->user()->role == 'admin')
                                     <td>


### PR DESCRIPTION
## Summary
- add `faculty_id` column to `subjects` with a migration
- relate `Subject` model to `Faculty`
- allow selecting a faculty when creating or editing subjects
- filter subjects by faculty in listing and course offering forms

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: could not find driver / missing app key)*

------
https://chatgpt.com/codex/tasks/task_b_684cfc5c64ac83259e9aa3ccd0424c2b