### PR TITLE
Rename subject difficulty column

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -59,7 +59,7 @@ class ReportController extends Controller
                         $q->where('semester_id', $semester->id);
                     })
                     ->join('subjects', 'class_sections.subject_id', '=', 'subjects.id')
-                    ->sum(DB::raw('class_sections.period_count * subjects.difficulty_ratio'));
+                    ->sum(DB::raw('class_sections.period_count * subjects.coefficient'));
                 $rows[] = [
                     'semester' => $semester->name . ' ' . $semester->academicYear->name,
                     'periods' => $periods,

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -60,7 +60,7 @@ class SubjectController extends Controller
             'code' => 'required|string|max:50|unique:subjects',
             'credits' => 'required|integer|min:1|max:10',
             'description' => 'nullable|string',
-            'difficulty_ratio' => 'nullable|numeric',
+            'coefficient' => 'nullable|numeric',
             'faculty_id' => 'required|exists:faculties,id',
         ]);
 
@@ -104,7 +104,7 @@ class SubjectController extends Controller
             'code' => 'required|string|max:50|unique:subjects,code,' . $subject->id,
             'credits' => 'required|integer|min:1|max:10',
             'description' => 'nullable|string',
-            'difficulty_ratio' => 'nullable|numeric',
+            'coefficient' => 'nullable|numeric',
             'faculty_id' => 'required|exists:faculties,id',
         ]);
 

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -19,7 +19,7 @@ class Subject extends Model
         'code',
         'credits',
         'description',
-        'difficulty_ratio',
+        'coefficient',
         'faculty_id',
     ];
 

--- a/app/Services/TeachingPaymentService.php
+++ b/app/Services/TeachingPaymentService.php
@@ -21,8 +21,8 @@ class TeachingPaymentService
             ->where('max_students', '>=', $studentCount)
             ->value('coefficient') ?? 1;
 
-        $difficulty = $subject->difficulty_ratio ?? 1;
+        $coefficient = $subject->coefficient ?? 1;
 
-        return $base * $degreeCoefficient * $classCoefficient * $difficulty * $periods;
+        return $base * $degreeCoefficient * $classCoefficient * $coefficient * $periods;
     }
 }

--- a/database/factories/SubjectFactory.php
+++ b/database/factories/SubjectFactory.php
@@ -17,7 +17,7 @@ class SubjectFactory extends Factory
             'code' => strtoupper($this->faker->unique()->lexify('SUB??')),
             'credits' => 3,
             'description' => $this->faker->sentence,
-            'difficulty_ratio' => 1,
+            'coefficient' => 1,
             'faculty_id' => Faculty::factory(),
         ];
     }

--- a/database/migrations/2025_06_14_044203_rename_difficulty_ratio_to_coefficient_in_subjects_table.php
+++ b/database/migrations/2025_06_14_044203_rename_difficulty_ratio_to_coefficient_in_subjects_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            $table->renameColumn('difficulty_ratio', 'coefficient');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('subjects', function (Blueprint $table) {
+            $table->renameColumn('coefficient', 'difficulty_ratio');
+        });
+    }
+};

--- a/database/seeders/SubjectSeeder.php
+++ b/database/seeders/SubjectSeeder.php
@@ -166,7 +166,7 @@ class SubjectSeeder extends Seeder
         ];
 
         foreach ($subjects as $subject) {
-            Subject::create($subject);
+            Subject::create($subject + ['coefficient' => 1]);
         }
     }
 }

--- a/resources/views/subjects/create.blade.php
+++ b/resources/views/subjects/create.blade.php
@@ -57,9 +57,9 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="difficulty_ratio" class="form-label">{{ __('Độ khó') }}</label>
-                            <input type="number" step="0.1" class="form-control @error('difficulty_ratio') is-invalid @enderror" id="difficulty_ratio" name="difficulty_ratio" value="{{ old('difficulty_ratio') }}">
-                            @error('difficulty_ratio')
+                            <label for="coefficient" class="form-label">{{ __('Hệ số học phần') }}</label>
+                            <input type="number" step="0.1" class="form-control @error('coefficient') is-invalid @enderror" id="coefficient" name="coefficient" value="{{ old('coefficient') }}">
+                            @error('coefficient')
                                 <div class="invalid-feedback">{{ $message }}</div>
                             @enderror
                         </div>

--- a/resources/views/subjects/edit.blade.php
+++ b/resources/views/subjects/edit.blade.php
@@ -58,9 +58,9 @@
                         </div>
 
                         <div class="mb-3">
-                            <label for="difficulty_ratio" class="form-label">{{ __('Độ khó') }}</label>
-                            <input type="number" step="0.1" class="form-control @error('difficulty_ratio') is-invalid @enderror" id="difficulty_ratio" name="difficulty_ratio" value="{{ old('difficulty_ratio', $subject->difficulty_ratio) }}">
-                            @error('difficulty_ratio')
+                            <label for="coefficient" class="form-label">{{ __('Hệ số học phần') }}</label>
+                            <input type="number" step="0.1" class="form-control @error('coefficient') is-invalid @enderror" id="coefficient" name="coefficient" value="{{ old('coefficient', $subject->coefficient) }}">
+                            @error('coefficient')
                                 <div class="invalid-feedback">{{ $message }}</div>
                             @enderror
                         </div>

--- a/resources/views/subjects/index.blade.php
+++ b/resources/views/subjects/index.blade.php
@@ -61,7 +61,7 @@
                                     <th width="15%">{{ __('Mã môn học') }}</th>
                                     <th width="35%">{{ __('Tên môn học') }}</th>
                                     <th width="10%">{{ __('Số tín chỉ') }}</th>
-                                    <th width="10%">{{ __('Độ khó') }}</th>
+                                    <th width="10%">{{ __('Hệ số học phần') }}</th>
                                     <th width="20%">{{ __('Khoa') }}</th>
                                     <th width="20%">{{ __('Mô tả') }}</th>
                                     @if(auth()->user()->role == 'admin')
@@ -76,7 +76,7 @@
                                    <td>{{ $subject->code }}</td>
                                    <td>{{ $subject->name }}</td>
                                    <td>{{ $subject->credits }}</td>
-                                   <td>{{ $subject->difficulty_ratio }}</td>
+                                   <td>{{ $subject->coefficient }}</td>
                                    <td>{{ $subject->faculty->name ?? '' }}</td>
                                    <td>{{ Str::limit($subject->description, 50) }}</td>
                                     @if(auth()->user()->role == 'admin')

--- a/resources/views/subjects/show.blade.php
+++ b/resources/views/subjects/show.blade.php
@@ -35,8 +35,8 @@
                             <div class="col-md-8">{{ $subject->credits }}</div>
                         </div>
                         <div class="row mt-2">
-                            <div class="col-md-4 fw-bold">{{ __('Độ khó:') }}</div>
-                            <div class="col-md-8">{{ $subject->difficulty_ratio }}</div>
+                            <div class="col-md-4 fw-bold">{{ __('Hệ số học phần:') }}</div>
+                            <div class="col-md-8">{{ $subject->coefficient }}</div>
                         </div>
                         <div class="row mt-2">
                             <div class="col-md-4 fw-bold">{{ __('Mô tả:') }}</div>

--- a/tests/Unit/TeachingPaymentServiceTest.php
+++ b/tests/Unit/TeachingPaymentServiceTest.php
@@ -19,7 +19,7 @@ class TeachingPaymentServiceTest extends TestCase
     {
         Degree::create(['id' => 1, 'name' => 'Dr', 'coefficient' => 1.5]);
         $teacher = new Teacher(['degree_id' => 1]);
-        $subject = new Subject(['difficulty_ratio' => 1.2]);
+        $subject = new Subject(['coefficient' => 1.2]);
 
         TeachingRate::unguard();
         TeachingRate::create(['id' => 1, 'amount' => 100]);


### PR DESCRIPTION
## Summary
- rename `difficulty_ratio` column to `coefficient`
- update fillable and validations
- update teacher payment calculation and reports
- adjust factories, seeders and tests
- update subject views
- add migration

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684e0a1b4de08325a387120fa38685a0