### PR TITLE
Add multi-section auto creation

### DIFF
--- a/app/Http/Controllers/ClassSectionController.php
+++ b/app/Http/Controllers/ClassSectionController.php
@@ -107,6 +107,7 @@ class ClassSectionController extends Controller
         $validator = Validator::make($request->all(), [
             'course_offering_id' => 'required|exists:course_offerings,id',
             'teacher_id' => 'required|exists:teachers,id',
+            'number_of_sections' => 'required|integer|min:1',
         ]);
         if ($validator->fails()) {
             return redirect()->back()->withErrors($validator)->withInput();
@@ -122,18 +123,24 @@ class ClassSectionController extends Controller
         if ($last) {
             $num = intval(substr($last->code, strlen($prefix))) + 1;
         }
-        $code = $prefix . str_pad($num, 2, '0', STR_PAD_LEFT);
+        $createdCodes = [];
+        for ($i = 0; $i < $request->number_of_sections; $i++) {
+            $code = $prefix . str_pad($num + $i, 2, '0', STR_PAD_LEFT);
 
-        ClassSection::create([
-            'code' => $code,
-            'course_offering_id' => $offering->id,
-            'subject_id' => $offering->subject_id,
-            'teacher_id' => $request->teacher_id,
-            'room' => $request->room,
-            'period_count' => $request->period_count ?? 0,
-            'student_count' => $request->student_count ?? 0,
-        ]);
+            ClassSection::create([
+                'code' => $code,
+                'course_offering_id' => $offering->id,
+                'subject_id' => $offering->subject_id,
+                'teacher_id' => $request->teacher_id,
+                'room' => $request->room,
+                'period_count' => $request->period_count ?? 0,
+                'student_count' => $request->student_count ?? 0,
+            ]);
 
-        return redirect()->route('class-sections.index')->with('success', 'Đã tạo lớp học phần ' . $code);
+            $createdCodes[] = $code;
+        }
+
+        return redirect()->route('class-sections.index')
+            ->with('success', 'Đã tạo lớp học phần: ' . implode(', ', $createdCodes));
     }
 }

--- a/resources/views/class_sections/create.blade.php
+++ b/resources/views/class_sections/create.blade.php
@@ -38,6 +38,10 @@
                                 <label class="form-label">{{ __('Phòng') }}</label>
                                 <input type="text" class="form-control" name="room" value="{{ old('room') }}">
                             </div>
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Số lớp cần tạo') }} <span class="text-danger">*</span></label>
+                                <input type="number" class="form-control" name="number_of_sections" value="{{ old('number_of_sections', 1) }}" min="1">
+                            </div>
                             <div class="d-grid gap-2">
                                 <button type="submit" class="btn btn-success">
                                     <i class="fas fa-magic"></i> {{ __('Tạo tự động') }}


### PR DESCRIPTION
## Summary
- allow specifying a number of sections when auto creating
- validate that number in `ClassSectionController::generate`
- loop over the requested count and generate incremental codes

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e0b53634c8325b1c609c0040bd755