### PR TITLE
Add scheduling seeders and factories

### DIFF
--- a/database/factories/ClassSizeCoefficientFactory.php
+++ b/database/factories/ClassSizeCoefficientFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ClassSizeCoefficient;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClassSizeCoefficientFactory extends Factory
+{
+    protected $model = ClassSizeCoefficient::class;
+
+    public function definition(): array
+    {
+        $min = $this->faker->numberBetween(1, 50);
+        return [
+            'min_students' => $min,
+            'max_students' => $min + $this->faker->numberBetween(1, 50),
+            'coefficient' => $this->faker->randomFloat(2, 1, 2),
+        ];
+    }
+}

--- a/database/factories/DegreeCoefficientFactory.php
+++ b/database/factories/DegreeCoefficientFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DegreeCoefficient;
+use App\Models\Degree;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DegreeCoefficientFactory extends Factory
+{
+    protected $model = DegreeCoefficient::class;
+
+    public function definition(): array
+    {
+        return [
+            'degree_id' => Degree::factory(),
+            'coefficient' => $this->faker->randomFloat(2, 1, 2),
+        ];
+    }
+}

--- a/database/factories/EnrollmentFactory.php
+++ b/database/factories/EnrollmentFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Enrollment;
+use App\Models\Student;
+use App\Models\ClassSection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class EnrollmentFactory extends Factory
+{
+    protected $model = Enrollment::class;
+
+    public function definition(): array
+    {
+        return [
+            'student_id' => Student::factory(),
+            'class_section_id' => ClassSection::factory(),
+        ];
+    }
+}

--- a/database/factories/TeachingRateFactory.php
+++ b/database/factories/TeachingRateFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TeachingRate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TeachingRateFactory extends Factory
+{
+    protected $model = TeachingRate::class;
+
+    public function definition(): array
+    {
+        return [
+            'amount' => $this->faker->randomFloat(2, 50, 200),
+        ];
+    }
+}

--- a/database/seeders/AcademicYearSeeder.php
+++ b/database/seeders/AcademicYearSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\AcademicYear;
+
+class AcademicYearSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $start = date('Y') - 1;
+        for ($i = 0; $i < 3; $i++) {
+            $year = $start + $i;
+            AcademicYear::create(['name' => $year.'-'.($year + 1)]);
+        }
+    }
+}

--- a/database/seeders/ClassSizeCoefficientSeeder.php
+++ b/database/seeders/ClassSizeCoefficientSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ClassSizeCoefficient;
+
+class ClassSizeCoefficientSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $ranges = [
+            ['min_students' => 1, 'max_students' => 30, 'coefficient' => 1.0],
+            ['min_students' => 31, 'max_students' => 60, 'coefficient' => 1.1],
+            ['min_students' => 61, 'max_students' => 100, 'coefficient' => 1.2],
+        ];
+
+        foreach ($ranges as $data) {
+            ClassSizeCoefficient::create($data);
+        }
+    }
+}

--- a/database/seeders/CourseOfferingSeeder.php
+++ b/database/seeders/CourseOfferingSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\CourseOffering;
+use App\Models\ClassSection;
+use App\Models\Semester;
+use App\Models\Subject;
+use App\Models\Teacher;
+
+class CourseOfferingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $semesters = Semester::all();
+        $subjects = Subject::all();
+        $teachers = Teacher::all();
+
+        foreach ($semesters as $semester) {
+            $offeredSubjects = $subjects->random(min(5, $subjects->count()));
+            foreach ($offeredSubjects as $subject) {
+                $offering = CourseOffering::create([
+                    'subject_id' => $subject->id,
+                    'semester_id' => $semester->id,
+                ]);
+
+                for ($i = 1; $i <= 2; $i++) {
+                    ClassSection::create([
+                        'code' => strtoupper($subject->code . $semester->id . $i),
+                        'course_offering_id' => $offering->id,
+                        'subject_id' => $subject->id,
+                        'teacher_id' => $teachers->random()->id,
+                        'room' => 'R' . rand(1, 10),
+                        'period_count' => 0,
+                        'student_count' => 0,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,13 @@ class DatabaseSeeder extends Seeder
             SubjectSeeder::class,      // Tạo môn học
             TeacherSeeder::class,      // Tạo giáo viên (phụ thuộc vào khoa và tài khoản)
             StudentSeeder::class,      // Tạo sinh viên (phụ thuộc vào lớp học và tài khoản)
+            AcademicYearSeeder::class, // Tạo năm học
+            SemesterSeeder::class,     // Tạo học kỳ (phụ thuộc năm học)
+            TeachingRateSeeder::class, // Tạo mức lương giảng dạy
+            DegreeCoefficientSeeder::class, // Tạo hệ số học vị
+            ClassSizeCoefficientSeeder::class, // Tạo hệ số sĩ số lớp
+            CourseOfferingSeeder::class, // Tạo các học phần và lớp học phần
+            EnrollmentSeeder::class,  // Đăng ký lớp học phần
             GradeSeeder::class,        // Tạo điểm số (phụ thuộc vào sinh viên và môn học)
         ]);
     }

--- a/database/seeders/DegreeCoefficientSeeder.php
+++ b/database/seeders/DegreeCoefficientSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Degree;
+use App\Models\DegreeCoefficient;
+
+class DegreeCoefficientSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $degrees = [
+            ['name' => 'Cu nhan', 'coeff' => 1.0],
+            ['name' => 'Thac si', 'coeff' => 1.2],
+            ['name' => 'Tien si', 'coeff' => 1.5],
+        ];
+
+        foreach ($degrees as $data) {
+            $degree = Degree::create([
+                'name' => $data['name'],
+                'coefficient' => $data['coeff'],
+            ]);
+            DegreeCoefficient::create([
+                'degree_id' => $degree->id,
+                'coefficient' => $data['coeff'],
+            ]);
+        }
+    }
+}

--- a/database/seeders/EnrollmentSeeder.php
+++ b/database/seeders/EnrollmentSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ClassSection;
+use App\Models\Enrollment;
+use App\Models\Student;
+
+class EnrollmentSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $students = Student::all();
+        $sections = ClassSection::all();
+
+        foreach ($sections as $section) {
+            $count = min(5, $students->count());
+            $selected = $students->random($count);
+            foreach ($selected as $student) {
+                Enrollment::create([
+                    'student_id' => $student->id,
+                    'class_section_id' => $section->id,
+                ]);
+                $section->increment('student_count');
+            }
+        }
+    }
+}

--- a/database/seeders/SemesterSeeder.php
+++ b/database/seeders/SemesterSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\AcademicYear;
+use App\Models\Semester;
+
+class SemesterSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $years = AcademicYear::all();
+        foreach ($years as $year) {
+            foreach ([1,2] as $i) {
+                Semester::create([
+                    'name' => 'HK'.$i,
+                    'academic_year_id' => $year->id,
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/TeachingRateSeeder.php
+++ b/database/seeders/TeachingRateSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\TeachingRate;
+
+class TeachingRateSeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach ([100000,120000,150000] as $amount) {
+            TeachingRate::create(['amount' => $amount]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed academic years and semesters
- seed teaching rates and coefficient tables
- seed course offerings with class sections and enrollments
- register the new seeders
- add model factories for new tables

## Testing
- `php artisan test` *(fails: `php` not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684e0c69b9e48325b1e144361f4a90ec