### PR TITLE
Add payroll module

### DIFF
--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Teacher;
+use App\Models\ClassSection;
+use App\Models\TeachingRate;
+use App\Models\ClassSizeCoefficient;
+use App\Services\TeachingPaymentService;
+use Illuminate\Support\Facades\Auth;
+
+class PayrollController extends Controller
+{
+    protected TeachingPaymentService $paymentService;
+
+    public function __construct(TeachingPaymentService $paymentService)
+    {
+        $this->middleware(['auth', 'role:admin,teacher']);
+        $this->paymentService = $paymentService;
+    }
+
+    public function index()
+    {
+        $user = Auth::user();
+
+        if ($user->role === 'admin') {
+            $teachers = Teacher::with(['degree', 'classSections.subject'])->get();
+
+            foreach ($teachers as $teacher) {
+                $total = 0;
+                foreach ($teacher->classSections as $section) {
+                    $total += $this->paymentService->calculate(
+                        $teacher,
+                        $section->subject,
+                        $section->student_count,
+                        $section->period_count
+                    );
+                }
+                $teacher->total_salary = $total;
+            }
+
+            return view('payrolls.index', [
+                'teachers' => $teachers,
+            ]);
+        }
+
+        $teacher = $user->teacher;
+        if (!$teacher) {
+            return redirect()->route('dashboard.index')
+                ->with('error', 'Không tìm thấy thông tin giáo viên.');
+        }
+
+        $sections = $teacher->classSections()->with('subject')->get();
+        foreach ($sections as $section) {
+            $section->salary = $this->paymentService->calculate(
+                $teacher,
+                $section->subject,
+                $section->student_count,
+                $section->period_count
+            );
+        }
+
+        return view('payrolls.index', [
+            'sections' => $sections,
+            'teacher' => $teacher,
+        ]);
+    }
+
+    public function show(Teacher $teacher)
+    {
+        $user = Auth::user();
+        if ($user->role === 'teacher' && $user->teacher?->id !== $teacher->id) {
+            return redirect()->route('payrolls.index')
+                ->with('error', 'Bạn không có quyền xem bảng lương này.');
+        }
+
+        $sections = $teacher->classSections()->with('subject')->get();
+        $details = [];
+        foreach ($sections as $section) {
+            $degree = $teacher->degree->coefficient ?? 1;
+            $classCoef = ClassSizeCoefficient::where('min_students', '<=', $section->student_count)
+                ->where('max_students', '>=', $section->student_count)
+                ->value('coefficient') ?? 1;
+            $subjectCoef = $section->subject->coefficient ?? 1;
+            $base = TeachingRate::orderByDesc('id')->value('amount') ?? 0;
+            $salary = $this->paymentService->calculate(
+                $teacher,
+                $section->subject,
+                $section->student_count,
+                $section->period_count
+            );
+            $details[] = [
+                'section' => $section,
+                'base' => $base,
+                'degree' => $degree,
+                'class' => $classCoef,
+                'subject' => $subjectCoef,
+                'salary' => $salary,
+            ];
+        }
+
+        $total = collect($details)->sum('salary');
+
+        return view('payrolls.show', [
+            'teacher' => $teacher,
+            'details' => $details,
+            'total' => $total,
+        ]);
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -356,6 +356,12 @@
                                 </div>
                             @endif
 
+                            @if(Auth::user()->role == 'admin' || Auth::user()->role == 'teacher')
+                                <a class="nav-link {{ request()->routeIs('payrolls.*') ? 'active' : '' }}" href="{{ route('payrolls.index') }}">
+                                    <i class="fas fa-money-check-alt"></i> Bảng lương
+                                </a>
+                            @endif
+
                             @if(Auth::user()->role == 'student' && Auth::user()->student)
                                 <a class="nav-link {{ request()->routeIs('students.transcript') ? 'active' : '' }}" href="{{ route('students.transcript', Auth::user()->student->id) }}">
                                     <i class="fas fa-chart-line"></i> Bảng điểm

--- a/resources/views/payrolls/index.blade.php
+++ b/resources/views/payrolls/index.blade.php
@@ -1,0 +1,77 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-10">
+            <div class="card">
+                <div class="card-header">Bảng lương</div>
+                <div class="card-body">
+                    @include('partials.alerts')
+
+                    @if(isset($teachers))
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-hover">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>#</th>
+                                        <th>Mã GV</th>
+                                        <th>Họ tên</th>
+                                        <th>Tổng lương</th>
+                                        <th width="10%">Thao tác</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($teachers as $index => $t)
+                                        <tr>
+                                            <td>{{ $index + 1 }}</td>
+                                            <td>{{ $t->teacher_id }}</td>
+                                            <td>{{ $t->full_name }}</td>
+                                            <td>{{ number_format($t->total_salary, 2) }}</td>
+                                            <td>
+                                                <a href="{{ route('payrolls.show', $t->id) }}" class="btn btn-sm btn-info">
+                                                    <i class="fas fa-eye"></i>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @elseif(isset($sections))
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-hover">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>#</th>
+                                        <th>Mã lớp HP</th>
+                                        <th>Môn học</th>
+                                        <th>Số tiết</th>
+                                        <th>Sĩ số</th>
+                                        <th>Lương</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($sections as $i => $section)
+                                        <tr>
+                                            <td>{{ $i + 1 }}</td>
+                                            <td>{{ $section->code }}</td>
+                                            <td>{{ $section->subject->name }}</td>
+                                            <td>{{ $section->period_count }}</td>
+                                            <td>{{ $section->student_count }}</td>
+                                            <td>{{ number_format($section->salary, 2) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="text-end fw-bold mt-3">
+                            Tổng lương: {{ number_format($sections->sum('salary'), 2) }}
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/payrolls/show.blade.php
+++ b/resources/views/payrolls/show.blade.php
@@ -1,0 +1,56 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-10">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>Bảng lương {{ $teacher->full_name }}</span>
+                    <a href="{{ route('payrolls.index') }}" class="btn btn-secondary btn-sm">
+                        <i class="fas fa-arrow-left"></i> Quay lại
+                    </a>
+                </div>
+                <div class="card-body">
+                    @include('partials.alerts')
+                    <div class="table-responsive">
+                        <table class="table table-bordered table-hover">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>#</th>
+                                    <th>Mã lớp HP</th>
+                                    <th>Môn học</th>
+                                    <th>Số tiết</th>
+                                    <th>Sĩ số</th>
+                                    <th>Hs học vị</th>
+                                    <th>Hs sĩ số</th>
+                                    <th>Hs môn</th>
+                                    <th>Lương</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($details as $i => $row)
+                                    <tr>
+                                        <td>{{ $i + 1 }}</td>
+                                        <td>{{ $row['section']->code }}</td>
+                                        <td>{{ $row['section']->subject->name }}</td>
+                                        <td>{{ $row['section']->period_count }}</td>
+                                        <td>{{ $row['section']->student_count }}</td>
+                                        <td>{{ $row['degree'] }}</td>
+                                        <td>{{ $row['class'] }}</td>
+                                        <td>{{ $row['subject'] }}</td>
+                                        <td>{{ number_format($row['salary'], 2) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="text-end fw-bold">
+                        Tổng lương: {{ number_format($total, 2) }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\TeachingRateController;
 use App\Http\Controllers\ClassSizeCoefficientController;
 use App\Http\Controllers\AcademicYearController;
 use App\Http\Controllers\SemesterController;
+use App\Http\Controllers\PayrollController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
 
@@ -88,9 +89,13 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 Route::middleware(['auth', 'role:admin,teacher'])->group(function () {
     // Quản lý sinh viên
     Route::resource('students', StudentController::class);
-    
+
     // Quản lý điểm số
     Route::resource('grades', GradeController::class);
+
+    // Bảng lương giáo viên
+    Route::get('payrolls', [PayrollController::class, 'index'])->name('payrolls.index');
+    Route::get('payrolls/{teacher}', [PayrollController::class, 'show'])->name('payrolls.show');
 });
 
 // Route xem bảng điểm sinh viên (cho admin, giáo viên và sinh viên đó)

--- a/tests/Feature/PayrollTest.php
+++ b/tests/Feature/PayrollTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClassSizeCoefficient;
+use App\Models\Degree;
+use App\Models\Subject;
+use App\Models\Teacher;
+use App\Models\TeachingRate;
+use App\Services\TeachingPaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PayrollTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_salary_calculation(): void
+    {
+        $rate = TeachingRate::factory()->create(['amount' => 100]);
+        $degree = Degree::factory()->create(['coefficient' => 1.2]);
+        ClassSizeCoefficient::factory()->create([
+            'min_students' => 0,
+            'max_students' => 50,
+            'coefficient' => 1.1,
+        ]);
+        $subject = Subject::factory()->create(['coefficient' => 1.5]);
+        $teacher = Teacher::factory()->create(['degree_id' => $degree->id]);
+
+        $service = new TeachingPaymentService();
+        $salary = $service->calculate($teacher, $subject, 30, 10);
+
+        $expected = 100 * 1.2 * 1.1 * 1.5 * 10;
+        $this->assertEquals($expected, $salary);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PayrollController` to view teacher payrolls
- expose payroll routes for admin and teacher roles
- add payroll listing and detail views
- show "Bảng lương" link in the sidebar
- basic test for salary calculation

## Testing
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68505d0587948325b0e339fee728b75d