### PR TITLE
Allow specifying period and student counts in auto section creation

### DIFF
--- a/app/Http/Controllers/ClassSectionController.php
+++ b/app/Http/Controllers/ClassSectionController.php
@@ -108,6 +108,8 @@ class ClassSectionController extends Controller
             'course_offering_id' => 'required|exists:course_offerings,id',
             'teacher_id' => 'required|exists:teachers,id',
             'number_of_sections' => 'required|integer|min:1',
+            'period_count' => 'required|integer|min:0',
+            'student_count' => 'required|integer|min:0',
         ]);
         if ($validator->fails()) {
             return redirect()->back()->withErrors($validator)->withInput();
@@ -133,8 +135,8 @@ class ClassSectionController extends Controller
                 'subject_id' => $offering->subject_id,
                 'teacher_id' => $request->teacher_id,
                 'room' => $request->room,
-                'period_count' => $request->period_count ?? 0,
-                'student_count' => $request->student_count ?? 0,
+                'period_count' => $request->period_count,
+                'student_count' => $request->student_count,
             ]);
 
             $createdCodes[] = $code;

--- a/resources/views/class_sections/create.blade.php
+++ b/resources/views/class_sections/create.blade.php
@@ -34,9 +34,19 @@
                                     @endforeach
                                 </select>
                             </div>
-                            <div class="mb-3">
-                                <label class="form-label">{{ __('Phòng') }}</label>
-                                <input type="text" class="form-control" name="room" value="{{ old('room') }}">
+                            <div class="row mb-3">
+                                <div class="col-md-6">
+                                    <label class="form-label">{{ __('Phòng') }}</label>
+                                    <input type="text" class="form-control" name="room" value="{{ old('room') }}">
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label">{{ __('Số tiết') }}</label>
+                                    <input type="number" class="form-control" name="period_count" value="{{ old('period_count', 0) }}">
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label">{{ __('Số SV') }}</label>
+                                    <input type="number" class="form-control" name="student_count" value="{{ old('student_count', 0) }}">
+                                </div>
                             </div>
                             <div class="mb-3">
                                 <label class="form-label">{{ __('Số lớp cần tạo') }} <span class="text-danger">*</span></label>


### PR DESCRIPTION
## Summary
- add period_count and student_count inputs to the auto creation form
- validate and persist those fields during auto generation

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68506373d1ec8325b79e651d9e04f029