### PR TITLE
Add semester filter for class section creation

### DIFF
--- a/app/Http/Controllers/ClassSectionController.php
+++ b/app/Http/Controllers/ClassSectionController.php
@@ -19,17 +19,35 @@ class ClassSectionController extends Controller
 
     public function create(Request $request)
     {
-        $courseOfferings = CourseOffering::with(['subject', 'semester.academicYear'])
-            ->when($request->semester_id, function ($q) use ($request) {
-                $q->where('semester_id', $request->semester_id);
-            })
-            ->get();
+        $courseOfferingsQuery = CourseOffering::with(['subject', 'semester.academicYear']);
+
+        if ($request->filled('academic_year_id')) {
+            $courseOfferingsQuery->whereHas('semester', function ($q) use ($request) {
+                $q->where('academic_year_id', $request->academic_year_id);
+            });
+        }
+
+        if ($request->filled('semester_id')) {
+            $courseOfferingsQuery->where('semester_id', $request->semester_id);
+        }
+
+        $courseOfferings = $courseOfferingsQuery->get();
+
         $teachers = Teacher::with('faculty')
             ->when($request->faculty_id, function ($q) use ($request) {
                 $q->where('faculty_id', $request->faculty_id);
             })
             ->get();
-        return view('class_sections.create', compact('courseOfferings', 'teachers'));
+
+        $academicYears = \App\Models\AcademicYear::with('semesters')->get();
+
+        $semestersQuery = \App\Models\Semester::with('academicYear');
+        if ($request->filled('academic_year_id')) {
+            $semestersQuery->where('academic_year_id', $request->academic_year_id);
+        }
+        $semesters = $semestersQuery->get();
+
+        return view('class_sections.create', compact('courseOfferings', 'teachers', 'academicYears', 'semesters'));
     }
 
     public function store(Request $request)

--- a/resources/views/class_sections/create.blade.php
+++ b/resources/views/class_sections/create.blade.php
@@ -13,6 +13,33 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+
+                    <div class="mb-3">
+                        <form action="{{ route('class-sections.create') }}" method="GET" class="row g-3">
+                            <input type="hidden" name="auto" value="{{ request('auto') }}">
+                            <div class="col-md-5">
+                                <select name="academic_year_id" class="form-select">
+                                    <option value="">{{ __('-- Năm học --') }}</option>
+                                    @foreach($academicYears as $year)
+                                        <option value="{{ $year->id }}" {{ request('academic_year_id') == $year->id ? 'selected' : '' }}>{{ $year->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="col-md-5">
+                                <select name="semester_id" class="form-select">
+                                    <option value="">{{ __('-- Học kỳ --') }}</option>
+                                    @foreach($semesters as $s)
+                                        <option value="{{ $s->id }}" {{ request('semester_id') == $s->id ? 'selected' : '' }}>{{ $s->name }} ({{ $s->academicYear->name }})</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="col-md-2">
+                                <button type="submit" class="btn btn-outline-primary w-100">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </div>
+                        </form>
+                    </div>
                     @if(request('auto'))
                         <form method="POST" action="{{ route('class-sections.generate') }}">
                             @csrf


### PR DESCRIPTION
## Summary
- filter class section course offerings by academic year and semester
- load academic years and semesters for create form
- add academic year/semester selectors to the class section creation page

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68506bf2abbc8325962e2fef18a97100