### PR TITLE
Add payroll PDF export

### DIFF
--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -7,6 +7,7 @@ use App\Models\ClassSection;
 use App\Models\TeachingRate;
 use App\Models\ClassSizeCoefficient;
 use App\Services\TeachingPaymentService;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Auth;
 
 class PayrollController extends Controller
@@ -106,5 +107,75 @@ class PayrollController extends Controller
             'details' => $details,
             'total' => $total,
         ]);
+    }
+
+    public function exportAll()
+    {
+        $user = Auth::user();
+        if ($user->role !== 'admin') {
+            return redirect()->route('payrolls.index')
+                ->with('error', 'Bạn không có quyền.');
+        }
+
+        $teachers = Teacher::with(['degree', 'classSections.subject'])->get();
+        foreach ($teachers as $teacher) {
+            $total = 0;
+            foreach ($teacher->classSections as $section) {
+                $total += $this->paymentService->calculate(
+                    $teacher,
+                    $section->subject,
+                    $section->student_count,
+                    $section->period_count
+                );
+            }
+            $teacher->total_salary = $total;
+        }
+
+        $pdf = Pdf::loadView('payrolls.list_pdf', ['teachers' => $teachers]);
+        return $pdf->stream('payrolls.pdf');
+    }
+
+    public function exportDetail(Teacher $teacher)
+    {
+        $user = Auth::user();
+        if ($user->role === 'teacher' && $user->teacher?->id !== $teacher->id) {
+            return redirect()->route('payrolls.index')
+                ->with('error', 'Bạn không có quyền.');
+        }
+
+        $sections = $teacher->classSections()->with('subject')->get();
+        $details = [];
+        foreach ($sections as $section) {
+            $degree = $teacher->degree->coefficient ?? 1;
+            $classCoef = ClassSizeCoefficient::where('min_students', '<=', $section->student_count)
+                ->where('max_students', '>=', $section->student_count)
+                ->value('coefficient') ?? 1;
+            $subjectCoef = $section->subject->coefficient ?? 1;
+            $base = TeachingRate::orderByDesc('id')->value('amount') ?? 0;
+            $salary = $this->paymentService->calculate(
+                $teacher,
+                $section->subject,
+                $section->student_count,
+                $section->period_count
+            );
+            $details[] = [
+                'section' => $section,
+                'base' => $base,
+                'degree' => $degree,
+                'class' => $classCoef,
+                'subject' => $subjectCoef,
+                'salary' => $salary,
+            ];
+        }
+
+        $total = collect($details)->sum('salary');
+
+        $pdf = Pdf::loadView('payrolls.detail_pdf', [
+            'teacher' => $teacher,
+            'details' => $details,
+            'total' => $total,
+        ]);
+
+        return $pdf->stream('payroll_' . $teacher->id . '.pdf');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
+        "barryvdh/laravel-dompdf": "^3.1",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,85 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8fac62fa000557439a1027c0c1519c98",
+    "content-hash": "c6ed296b7f7a718cbed7be50543dfa5b",
     "packages": [
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9|^10",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-13T15:07:54+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.12.3",
@@ -377,6 +454,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "a51bd7a063a65499446919286fb18b518177155a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/a51bd7a063a65499446919286fb18b518177155a",
+                "reference": "a51bd7a063a65499446919286fb18b518177155a",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.0"
+            },
+            "time": "2025-01-15T14:09:04+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.0"
+            },
+            "time": "2024-04-29T13:26:35+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -1953,6 +2185,73 @@
             "time": "2024-09-21T08:32:55+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
+                "reference": "f5ac2c0b0a2eefca70b2ce32a5809992227e75a6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.9.0"
+            },
+            "time": "2024-03-31T07:05:07+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.8.1",
             "source": {
@@ -3230,6 +3529,71 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v8.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "3de493bdddfd1f051249af725c7e0d2c38fed740"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/3de493bdddfd1f051249af725c7e0d2c38fed740",
+                "reference": "3de493bdddfd1f051249af725c7e0d2c38fed740",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.8.0"
+            },
+            "time": "2025-03-23T17:59:05+00:00"
         },
         {
             "name": "symfony/console",
@@ -8177,12 +8541,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/resources/views/payrolls/detail_pdf.blade.php
+++ b/resources/views/payrolls/detail_pdf.blade.php
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #000; padding: 4px; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <h1>Bảng lương {{ $teacher->full_name }}</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Mã lớp HP</th>
+                <th>Môn học</th>
+                <th>Số tiết</th>
+                <th>Sĩ số</th>
+                <th>Hs học vị</th>
+                <th>Hs sĩ số</th>
+                <th>Hs môn</th>
+                <th>Lương</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($details as $i => $row)
+                <tr>
+                    <td>{{ $i + 1 }}</td>
+                    <td>{{ $row['section']->code }}</td>
+                    <td>{{ $row['section']->subject->name }}</td>
+                    <td>{{ $row['section']->period_count }}</td>
+                    <td>{{ $row['section']->student_count }}</td>
+                    <td>{{ $row['degree'] }}</td>
+                    <td>{{ $row['class'] }}</td>
+                    <td>{{ $row['subject'] }}</td>
+                    <td>{{ number_format($row['salary'], 2) }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <p style="text-align: right; font-weight: bold;">Tổng lương: {{ number_format($total, 2) }}</p>
+</body>
+</html>

--- a/resources/views/payrolls/index.blade.php
+++ b/resources/views/payrolls/index.blade.php
@@ -5,7 +5,14 @@
     <div class="row justify-content-center">
         <div class="col-md-10">
             <div class="card">
-                <div class="card-header">Bảng lương</div>
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <span>Bảng lương</span>
+                    @if(isset($teachers))
+                        <a href="{{ route('payrolls.export') }}" class="btn btn-sm btn-primary">Xuất PDF</a>
+                    @elseif(isset($teacher))
+                        <a href="{{ route('payrolls.export_detail', $teacher) }}" class="btn btn-sm btn-primary">Xuất PDF</a>
+                    @endif
+                </div>
                 <div class="card-body">
                     @include('partials.alerts')
 

--- a/resources/views/payrolls/list_pdf.blade.php
+++ b/resources/views/payrolls/list_pdf.blade.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #000; padding: 4px; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <h1>Bảng lương giáo viên</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Mã GV</th>
+                <th>Họ tên</th>
+                <th>Tổng lương</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($teachers as $index => $t)
+                <tr>
+                    <td>{{ $index + 1 }}</td>
+                    <td>{{ $t->teacher_id }}</td>
+                    <td>{{ $t->full_name }}</td>
+                    <td>{{ number_format($t->total_salary, 2) }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</body>
+</html>

--- a/resources/views/payrolls/show.blade.php
+++ b/resources/views/payrolls/show.blade.php
@@ -7,9 +7,12 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <span>Bảng lương {{ $teacher->full_name }}</span>
-                    <a href="{{ route('payrolls.index') }}" class="btn btn-secondary btn-sm">
-                        <i class="fas fa-arrow-left"></i> Quay lại
-                    </a>
+                    <div>
+                        <a href="{{ route('payrolls.export_detail', $teacher) }}" class="btn btn-primary btn-sm me-2">Xuất PDF</a>
+                        <a href="{{ route('payrolls.index') }}" class="btn btn-secondary btn-sm">
+                            <i class="fas fa-arrow-left"></i> Quay lại
+                        </a>
+                    </div>
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,6 +94,8 @@ Route::middleware(['auth', 'role:admin,teacher'])->group(function () {
     Route::resource('grades', GradeController::class);
 
     // Bảng lương giáo viên
+    Route::get('payrolls/export', [PayrollController::class, 'exportAll'])->name('payrolls.export');
+    Route::get('payrolls/{teacher}/export', [PayrollController::class, 'exportDetail'])->name('payrolls.export_detail');
     Route::get('payrolls', [PayrollController::class, 'index'])->name('payrolls.index');
     Route::get('payrolls/{teacher}', [PayrollController::class, 'show'])->name('payrolls.show');
 });

--- a/tests/Feature/PayrollPdfTest.php
+++ b/tests/Feature/PayrollPdfTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClassSection;
+use App\Models\ClassSizeCoefficient;
+use App\Models\Degree;
+use App\Models\Subject;
+use App\Models\Teacher;
+use App\Models\TeachingRate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PayrollPdfTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpData(): Teacher
+    {
+        TeachingRate::factory()->create(['amount' => 100]);
+        ClassSizeCoefficient::factory()->create([
+            'min_students' => 0,
+            'max_students' => 50,
+            'coefficient' => 1.1,
+        ]);
+        $degree = Degree::factory()->create(['coefficient' => 1.2]);
+        $subject = Subject::factory()->create(['coefficient' => 1.5]);
+        $teacher = Teacher::factory()->create(['degree_id' => $degree->id]);
+        ClassSection::factory()->create([
+            'teacher_id' => $teacher->id,
+            'subject_id' => $subject->id,
+            'period_count' => 10,
+            'student_count' => 30,
+        ]);
+        return $teacher;
+    }
+
+    public function test_export_routes_return_pdf(): void
+    {
+        $teacher = $this->setUpData();
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $res = $this->actingAs($admin)->get(route('payrolls.export'));
+        $res->assertOk();
+        $this->assertStringContainsString('application/pdf', $res->headers->get('content-type'));
+
+        $res = $this->actingAs($admin)->get(route('payrolls.export_detail', $teacher));
+        $res->assertOk();
+        $this->assertStringContainsString('application/pdf', $res->headers->get('content-type'));
+    }
+}


### PR DESCRIPTION
## Summary
- install `barryvdh/laravel-dompdf`
- add export actions in `PayrollController`
- create PDF blade views for payroll export
- wire up export routes
- add export buttons to payroll views
- test PDF endpoints

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_68507c6aaf6c832589698bfd29583bba