### PR TITLE
Add academic year filter for payroll

### DIFF
--- a/resources/views/payrolls/index.blade.php
+++ b/resources/views/payrolls/index.blade.php
@@ -16,6 +16,31 @@
                 <div class="card-body">
                     @include('partials.alerts')
 
+                    <div class="mb-3">
+                        <form action="{{ route('payrolls.index') }}" method="GET" class="row g-3">
+                            <div class="col-md-4">
+                                <select name="academic_year_id" class="form-select">
+                                    <option value="">{{ __('-- Năm học --') }}</option>
+                                    @foreach($academicYears as $year)
+                                        <option value="{{ $year->id }}" {{ request('academic_year_id') == $year->id ? 'selected' : '' }}>
+                                            {{ $year->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="col-md-2">
+                                <button type="submit" class="btn btn-outline-primary w-100">
+                                    <i class="fas fa-filter"></i>
+                                </button>
+                            </div>
+                            <div class="col-md-2">
+                                <a href="{{ route('payrolls.index') }}" class="btn btn-outline-secondary w-100">
+                                    <i class="fas fa-redo"></i>
+                                </a>
+                            </div>
+                        </form>
+                    </div>
+
                     @if(isset($teachers))
                         <div class="table-responsive">
                             <table class="table table-bordered table-hover">

--- a/resources/views/payrolls/show.blade.php
+++ b/resources/views/payrolls/show.blade.php
@@ -16,6 +16,31 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+
+                    <div class="mb-3">
+                        <form action="{{ route('payrolls.show', $teacher) }}" method="GET" class="row g-3">
+                            <div class="col-md-4">
+                                <select name="academic_year_id" class="form-select">
+                                    <option value="">{{ __('-- Năm học --') }}</option>
+                                    @foreach($academicYears as $year)
+                                        <option value="{{ $year->id }}" {{ request('academic_year_id') == $year->id ? 'selected' : '' }}>
+                                            {{ $year->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="col-md-2">
+                                <button type="submit" class="btn btn-outline-primary w-100">
+                                    <i class="fas fa-filter"></i>
+                                </button>
+                            </div>
+                            <div class="col-md-2">
+                                <a href="{{ route('payrolls.show', $teacher) }}" class="btn btn-outline-secondary w-100">
+                                    <i class="fas fa-redo"></i>
+                                </a>
+                            </div>
+                        </form>
+                    </div>
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">
                             <thead class="table-light">


### PR DESCRIPTION
## Summary
- filter payroll data by `academic_year_id` in `PayrollController`
- query class sections by academic year
- add year selector to payroll index and detail views

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6850d9b723b8832594c9a84970fb6642