### PR TITLE
Add totals for payroll exports

### DIFF
--- a/resources/views/payrolls/index.blade.php
+++ b/resources/views/payrolls/index.blade.php
@@ -8,9 +8,9 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <span>Bảng lương</span>
                     @if(Auth::user()->role === 'admin')
-                        <a href="{{ route('payrolls.export') }}" class="btn btn-sm btn-primary">Xuất PDF</a>
+                        <a href="{{ route('payrolls.export', request()->query()) }}" class="btn btn-sm btn-primary">Xuất PDF</a>
                     @else
-                        <a href="{{ route('payrolls.export_detail', $teacher) }}" class="btn btn-sm btn-primary">Xuất PDF</a>
+                        <a href="{{ route('payrolls.export_detail', array_merge(['teacher' => $teacher->id], request()->query())) }}" class="btn btn-sm btn-primary">Xuất PDF</a>
                     @endif
                 </div>
                 <div class="card-body">

--- a/resources/views/payrolls/list_pdf.blade.php
+++ b/resources/views/payrolls/list_pdf.blade.php
@@ -28,6 +28,14 @@
                 </tr>
             @endforeach
         </tbody>
+        @isset($total)
+            <tfoot>
+                <tr>
+                    <td colspan="3" style="text-align: right; font-weight: bold;">Tổng cộng</td>
+                    <td>{{ number_format($total, 2) }}</td>
+                </tr>
+            </tfoot>
+        @endisset
     </table>
 </body>
 </html>

--- a/resources/views/payrolls/show.blade.php
+++ b/resources/views/payrolls/show.blade.php
@@ -8,7 +8,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <span>Bảng lương {{ $teacher->full_name }}</span>
                     <div>
-                        <a href="{{ route('payrolls.export_detail', $teacher) }}" class="btn btn-primary btn-sm me-2">Xuất PDF</a>
+                        <a href="{{ route('payrolls.export_detail', array_merge(['teacher' => $teacher->id], request()->query())) }}" class="btn btn-primary btn-sm me-2">Xuất PDF</a>
                         <a href="{{ route('payrolls.index') }}" class="btn btn-secondary btn-sm">
                             <i class="fas fa-arrow-left"></i> Quay lại
                         </a>

--- a/tests/Feature/PayrollTotalsTest.php
+++ b/tests/Feature/PayrollTotalsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AcademicYear;
+use App\Models\ClassSection;
+use App\Models\ClassSizeCoefficient;
+use App\Models\CourseOffering;
+use App\Models\Degree;
+use App\Models\Semester;
+use App\Models\Subject;
+use App\Models\Teacher;
+use App\Models\TeachingRate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PayrollTotalsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedData(): array
+    {
+        $year = AcademicYear::factory()->create();
+        $semester = Semester::factory()->create(['academic_year_id' => $year->id]);
+        $otherSemester = Semester::factory()->create(['academic_year_id' => $year->id]);
+
+        TeachingRate::factory()->create(['amount' => 100]);
+        ClassSizeCoefficient::factory()->create(['min_students' => 0, 'max_students' => 50, 'coefficient' => 1]);
+        $degree = Degree::factory()->create(['coefficient' => 1]);
+        $subject = Subject::factory()->create(['coefficient' => 1]);
+        $teacher = Teacher::factory()->create(['degree_id' => $degree->id]);
+
+        $offering1 = CourseOffering::factory()->create(['subject_id' => $subject->id, 'semester_id' => $semester->id]);
+        $offering2 = CourseOffering::factory()->create(['subject_id' => $subject->id, 'semester_id' => $otherSemester->id]);
+
+        ClassSection::factory()->create([
+            'teacher_id' => $teacher->id,
+            'subject_id' => $subject->id,
+            'course_offering_id' => $offering1->id,
+            'period_count' => 10,
+            'student_count' => 20,
+        ]);
+
+        ClassSection::factory()->create([
+            'teacher_id' => $teacher->id,
+            'subject_id' => $subject->id,
+            'course_offering_id' => $offering2->id,
+            'period_count' => 5,
+            'student_count' => 20,
+        ]);
+
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        return [$admin, $teacher, $year, $semester];
+    }
+
+    public function test_totals_filtered_by_semester(): void
+    {
+        [$admin, $teacher, $year, $semester] = $this->seedData();
+
+        $response = $this->actingAs($admin)->get(route('payrolls.index', [
+            'academic_year_id' => $year->id,
+            'semester_id' => $semester->id,
+        ]));
+
+        $response->assertOk();
+        $response->assertViewHas('total', 1000.0);
+
+        $pdf = $this->actingAs($admin)->get(route('payrolls.export', [
+            'academic_year_id' => $year->id,
+            'semester_id' => $semester->id,
+        ]));
+
+        $pdf->assertOk();
+        $this->assertStringContainsString('application/pdf', $pdf->headers->get('content-type'));
+    }
+}


### PR DESCRIPTION
## Summary
- compute totals when exporting payrolls with optional filters
- show totals in PDF export and maintain filters in export links
- test payroll totals with semester filter

## Testing
- `php vendor/bin/phpunit --stop-on-failure --testdox`

------
https://chatgpt.com/codex/tasks/task_b_6850deaa4d208325a823e674ba207778