### PR TITLE
Add teaching rate support for class sections

### DIFF
--- a/app/Http/Controllers/ClassSectionController.php
+++ b/app/Http/Controllers/ClassSectionController.php
@@ -7,6 +7,7 @@ use App\Models\Subject;
 use App\Models\CourseOffering;
 use App\Models\Teacher;
 use App\Models\Faculty;
+use App\Models\TeachingRate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
@@ -56,7 +57,9 @@ class ClassSectionController extends Controller
         }
         $semesters = $semestersQuery->get();
 
-        return view('class_sections.create', compact('courseOfferings', 'teachers', 'academicYears', 'semesters', 'faculties'));
+        $teachingRates = TeachingRate::all();
+
+        return view('class_sections.create', compact('courseOfferings', 'teachers', 'academicYears', 'semesters', 'faculties', 'teachingRates'));
     }
 
     public function store(Request $request)
@@ -65,6 +68,7 @@ class ClassSectionController extends Controller
             'code' => 'required|unique:class_sections,code',
             'course_offering_id' => 'required|exists:course_offerings,id',
             'teacher_id' => 'required|exists:teachers,id',
+            'teaching_rate_id' => 'required|exists:teaching_rates,id',
             'room' => 'nullable|string',
             'period_count' => 'required|integer|min:0',
             'student_count' => 'required|integer|min:0',
@@ -79,6 +83,7 @@ class ClassSectionController extends Controller
             'course_offering_id' => $offering->id,
             'subject_id' => $offering->subject_id,
             'teacher_id' => $request->teacher_id,
+            'teaching_rate_id' => $request->teaching_rate_id,
             'room' => $request->room,
             'period_count' => $request->period_count,
             'student_count' => $request->student_count,
@@ -90,7 +95,8 @@ class ClassSectionController extends Controller
     {
         $courseOfferings = CourseOffering::with(['subject', 'semester.academicYear'])->get();
         $teachers = Teacher::with('faculty')->get();
-        return view('class_sections.edit', compact('classSection', 'courseOfferings', 'teachers'));
+        $teachingRates = TeachingRate::all();
+        return view('class_sections.edit', compact('classSection', 'courseOfferings', 'teachers', 'teachingRates'));
     }
 
     public function update(Request $request, ClassSection $classSection)
@@ -99,6 +105,7 @@ class ClassSectionController extends Controller
             'code' => 'required|unique:class_sections,code,' . $classSection->id,
             'course_offering_id' => 'required|exists:course_offerings,id',
             'teacher_id' => 'required|exists:teachers,id',
+            'teaching_rate_id' => 'required|exists:teaching_rates,id',
             'room' => 'nullable|string',
             'period_count' => 'required|integer|min:0',
             'student_count' => 'required|integer|min:0',
@@ -113,6 +120,7 @@ class ClassSectionController extends Controller
             'course_offering_id' => $offering->id,
             'subject_id' => $offering->subject_id,
             'teacher_id' => $request->teacher_id,
+            'teaching_rate_id' => $request->teaching_rate_id,
             'room' => $request->room,
             'period_count' => $request->period_count,
             'student_count' => $request->student_count,
@@ -134,6 +142,7 @@ class ClassSectionController extends Controller
         $validator = Validator::make($request->all(), [
             'course_offering_id' => 'required|exists:course_offerings,id',
             'teacher_id' => 'required|exists:teachers,id',
+            'teaching_rate_id' => 'required|exists:teaching_rates,id',
             'number_of_sections' => 'required|integer|min:1',
             'period_count' => 'required|integer|min:0',
             'student_count' => 'required|integer|min:0',
@@ -161,6 +170,7 @@ class ClassSectionController extends Controller
                 'course_offering_id' => $offering->id,
                 'subject_id' => $offering->subject_id,
                 'teacher_id' => $request->teacher_id,
+                'teaching_rate_id' => $request->teaching_rate_id,
                 'room' => $request->room,
                 'period_count' => $request->period_count,
                 'student_count' => $request->student_count,

--- a/app/Http/Controllers/PayrollController.php
+++ b/app/Http/Controllers/PayrollController.php
@@ -33,7 +33,7 @@ class PayrollController extends Controller
             $coefficients = ClassSizeCoefficient::all();
             $paymentService = new TeachingPaymentService($base, $coefficients);
 
-            $sections = ClassSection::with(['subject', 'teacher', 'courseOffering.semester'])
+            $sections = ClassSection::with(['subject', 'teacher', 'courseOffering.semester', 'teachingRate'])
                 ->when($yearId, function ($q) use ($yearId) {
                     $q->whereHas('courseOffering.semester', function ($q) use ($yearId) {
                         $q->where('academic_year_id', $yearId);
@@ -51,7 +51,8 @@ class PayrollController extends Controller
                     $section->teacher,
                     $section->subject,
                     $section->student_count,
-                    $section->period_count
+                    $section->period_count,
+                    optional($section->teachingRate)->amount
                 );
             }
 
@@ -74,7 +75,7 @@ class PayrollController extends Controller
         $paymentService = new TeachingPaymentService($base, $coefficients);
 
         $sections = $teacher->classSections()
-            ->with(['subject', 'courseOffering.semester'])
+            ->with(['subject', 'courseOffering.semester', 'teachingRate'])
             ->when($yearId, function ($q) use ($yearId) {
                 $q->whereHas('courseOffering.semester', function ($q) use ($yearId) {
                     $q->where('academic_year_id', $yearId);
@@ -91,7 +92,8 @@ class PayrollController extends Controller
                 $teacher,
                 $section->subject,
                 $section->student_count,
-                $section->period_count
+                $section->period_count,
+                optional($section->teachingRate)->amount
             );
         }
 
@@ -122,7 +124,7 @@ class PayrollController extends Controller
         $paymentService = new TeachingPaymentService($base, $coefficients);
 
         $sections = $teacher->classSections()
-            ->with(['subject', 'courseOffering.semester'])
+            ->with(['subject', 'courseOffering.semester', 'teachingRate'])
             ->when($yearId, function ($q) use ($yearId) {
                 $q->whereHas('courseOffering.semester', function ($q) use ($yearId) {
                     $q->where('academic_year_id', $yearId);
@@ -147,7 +149,8 @@ class PayrollController extends Controller
                 $teacher,
                 $section->subject,
                 $section->student_count,
-                $section->period_count
+                $section->period_count,
+                optional($section->teachingRate)->amount
             );
             $details[] = [
                 'section' => $section,
@@ -183,7 +186,7 @@ class PayrollController extends Controller
         $yearId = $request->academic_year_id;
         $semesterId = $request->semester_id;
 
-        $teachers = Teacher::with(['degree', 'classSections.subject', 'classSections.courseOffering.semester'])
+        $teachers = Teacher::with(['degree', 'classSections.subject', 'classSections.courseOffering.semester', 'classSections.teachingRate'])
             ->get();
         $base = TeachingRate::orderByDesc('id')->value('amount') ?? 0;
         $coefficients = ClassSizeCoefficient::all();
@@ -209,7 +212,8 @@ class PayrollController extends Controller
                     $teacher,
                     $section->subject,
                     $section->student_count,
-                    $section->period_count
+                    $section->period_count,
+                    optional($section->teachingRate)->amount
                 );
             }
             $teacher->total_salary = $total;
@@ -240,7 +244,7 @@ class PayrollController extends Controller
         $paymentService = new TeachingPaymentService($base, $coefficients);
 
         $sections = $teacher->classSections()
-            ->with(['subject', 'courseOffering.semester'])
+            ->with(['subject', 'courseOffering.semester', 'teachingRate'])
             ->when($yearId, function ($q) use ($yearId) {
                 $q->whereHas('courseOffering.semester', function ($q) use ($yearId) {
                     $q->where('academic_year_id', $yearId);
@@ -265,7 +269,8 @@ class PayrollController extends Controller
                 $teacher,
                 $section->subject,
                 $section->student_count,
-                $section->period_count
+                $section->period_count,
+                optional($section->teachingRate)->amount
             );
             $details[] = [
                 'section' => $section,
@@ -313,7 +318,8 @@ class PayrollController extends Controller
             $teacher,
             $classSection->subject,
             $classSection->student_count,
-            $classSection->period_count
+            $classSection->period_count,
+            optional($classSection->teachingRate)->amount
         );
 
         return view('payrolls.section', [

--- a/app/Models/ClassSection.php
+++ b/app/Models/ClassSection.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\Student;
 use App\Models\Enrollment;
+use App\Models\TeachingRate;
 
 class ClassSection extends Model
 {
@@ -19,6 +20,7 @@ class ClassSection extends Model
         'course_offering_id',
         'subject_id',
         'teacher_id',
+        'teaching_rate_id',
         'room',
         'period_count',
         'student_count',
@@ -32,6 +34,11 @@ class ClassSection extends Model
     public function teacher(): BelongsTo
     {
         return $this->belongsTo(Teacher::class);
+    }
+
+    public function teachingRate(): BelongsTo
+    {
+        return $this->belongsTo(TeachingRate::class);
     }
 
     public function courseOffering(): BelongsTo

--- a/app/Services/TeachingPaymentService.php
+++ b/app/Services/TeachingPaymentService.php
@@ -21,7 +21,7 @@ class TeachingPaymentService
         $this->classCoefficients = $classCoefficients;
     }
 
-    public function calculate(Teacher $teacher, Subject $subject, int $studentCount, int $periods): float
+    public function calculate(Teacher $teacher, Subject $subject, int $studentCount, int $periods, ?float $rate = null): float
     {
         $degreeCoefficient = $teacher->degree->coefficient ?? 1;
 
@@ -33,7 +33,9 @@ class TeachingPaymentService
 
         $subjectCoefficient = $subject->coefficient ?? 1;
 
-        return $this->baseRate * $degreeCoefficient * $classCoefficient * $subjectCoefficient * $periods;
+        $base = $rate ?? $this->baseRate;
+
+        return $base * $degreeCoefficient * $classCoefficient * $subjectCoefficient * $periods;
     }
 
     /**
@@ -54,7 +56,8 @@ class TeachingPaymentService
                 $teacher,
                 $section->subject,
                 $section->student_count,
-                $section->period_count
+                $section->period_count,
+                optional($section->teachingRate)->amount
             );
         }
 

--- a/database/factories/ClassSectionFactory.php
+++ b/database/factories/ClassSectionFactory.php
@@ -6,6 +6,7 @@ use App\Models\ClassSection;
 use App\Models\CourseOffering;
 use App\Models\Subject;
 use App\Models\Teacher;
+use App\Models\TeachingRate;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class ClassSectionFactory extends Factory
@@ -19,6 +20,7 @@ class ClassSectionFactory extends Factory
             'course_offering_id' => CourseOffering::factory(),
             'subject_id' => Subject::factory(),
             'teacher_id' => Teacher::factory(),
+            'teaching_rate_id' => TeachingRate::factory(),
             'room' => 'R' . $this->faker->numberBetween(1, 10),
             'period_count' => 0,
             'student_count' => 30,

--- a/database/migrations/2024_03_06_000018_add_teaching_rate_id_to_class_sections_table.php
+++ b/database/migrations/2024_03_06_000018_add_teaching_rate_id_to_class_sections_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('class_sections', function (Blueprint $table) {
+            $table->foreignId('teaching_rate_id')->nullable()->after('teacher_id')->constrained('teaching_rates');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('class_sections', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('teaching_rate_id');
+        });
+    }
+};

--- a/database/seeders/CourseOfferingSeeder.php
+++ b/database/seeders/CourseOfferingSeeder.php
@@ -8,6 +8,7 @@ use App\Models\ClassSection;
 use App\Models\Semester;
 use App\Models\Subject;
 use App\Models\Teacher;
+use App\Models\TeachingRate;
 
 class CourseOfferingSeeder extends Seeder
 {
@@ -16,6 +17,7 @@ class CourseOfferingSeeder extends Seeder
         $semesters = Semester::all();
         $subjects = Subject::all();
         $teachers = Teacher::all();
+        $rates = TeachingRate::all();
 
         foreach ($semesters as $semester) {
             $offeredSubjects = $subjects->random(min(5, $subjects->count()));
@@ -31,6 +33,7 @@ class CourseOfferingSeeder extends Seeder
                         'course_offering_id' => $offering->id,
                         'subject_id' => $subject->id,
                         'teacher_id' => $teachers->random()->id,
+                        'teaching_rate_id' => $rates->random()->id,
                         'room' => 'R' . rand(1, 10),
                         'period_count' => 0,
                         'student_count' => 0,

--- a/resources/views/class_sections/create.blade.php
+++ b/resources/views/class_sections/create.blade.php
@@ -69,6 +69,15 @@
                                     @endforeach
                                 </select>
                             </div>
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Định mức lương') }} <span class="text-danger">*</span></label>
+                                <select class="form-select" name="teaching_rate_id" required>
+                                    <option value="">{{ __('-- Chọn định mức --') }}</option>
+                                    @foreach($teachingRates as $rate)
+                                        <option value="{{ $rate->id }}">{{ number_format($rate->amount, 0, ',', '.') }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
                             <div class="row mb-3">
                                 <div class="col-md-6">
                                     <label class="form-label">{{ __('Phòng') }}</label>
@@ -115,6 +124,15 @@
                                     <option value="">{{ __('-- Chọn giáo viên --') }}</option>
                                     @foreach($teachers as $teacher)
                                         <option value="{{ $teacher->id }}" {{ old('teacher_id') == $teacher->id ? 'selected' : '' }}>{{ $teacher->full_name }} - {{ $teacher->faculty->name }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">{{ __('Định mức lương') }} <span class="text-danger">*</span></label>
+                                <select class="form-select" name="teaching_rate_id" required>
+                                    <option value="">{{ __('-- Chọn định mức --') }}</option>
+                                    @foreach($teachingRates as $rate)
+                                        <option value="{{ $rate->id }}" {{ old('teaching_rate_id') == $rate->id ? 'selected' : '' }}>{{ number_format($rate->amount, 0, ',', '.') }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/resources/views/class_sections/edit.blade.php
+++ b/resources/views/class_sections/edit.blade.php
@@ -36,6 +36,14 @@
                                 @endforeach
                             </select>
                         </div>
+                        <div class="mb-3">
+                            <label class="form-label">{{ __('Định mức lương') }} <span class="text-danger">*</span></label>
+                            <select class="form-select" name="teaching_rate_id" required>
+                                @foreach($teachingRates as $rate)
+                                    <option value="{{ $rate->id }}" {{ $classSection->teaching_rate_id == $rate->id ? 'selected' : '' }}>{{ number_format($rate->amount, 0, ',', '.') }}</option>
+                                @endforeach
+                            </select>
+                        </div>
                         <div class="row mb-3">
                             <div class="col-md-6">
                                 <label class="form-label">{{ __('Phòng') }}</label>

--- a/tests/Feature/PayrollPdfTest.php
+++ b/tests/Feature/PayrollPdfTest.php
@@ -18,7 +18,7 @@ class PayrollPdfTest extends TestCase
 
     private function setUpData(): Teacher
     {
-        TeachingRate::factory()->create(['amount' => 100]);
+        $rate = TeachingRate::factory()->create(['amount' => 100]);
         ClassSizeCoefficient::factory()->create([
             'min_students' => 0,
             'max_students' => 50,
@@ -30,6 +30,7 @@ class PayrollPdfTest extends TestCase
         ClassSection::factory()->create([
             'teacher_id' => $teacher->id,
             'subject_id' => $subject->id,
+            'teaching_rate_id' => $rate->id,
             'period_count' => 10,
             'student_count' => 30,
         ]);

--- a/tests/Feature/PayrollTotalsTest.php
+++ b/tests/Feature/PayrollTotalsTest.php
@@ -25,7 +25,7 @@ class PayrollTotalsTest extends TestCase
         $semester = Semester::factory()->create(['academic_year_id' => $year->id]);
         $otherSemester = Semester::factory()->create(['academic_year_id' => $year->id]);
 
-        TeachingRate::factory()->create(['amount' => 100]);
+        $rate = TeachingRate::factory()->create(['amount' => 100]);
         ClassSizeCoefficient::factory()->create(['min_students' => 0, 'max_students' => 50, 'coefficient' => 1]);
         $degree = Degree::factory()->create(['coefficient' => 1]);
         $subject = Subject::factory()->create(['coefficient' => 1]);
@@ -38,6 +38,7 @@ class PayrollTotalsTest extends TestCase
             'teacher_id' => $teacher->id,
             'subject_id' => $subject->id,
             'course_offering_id' => $offering1->id,
+            'teaching_rate_id' => $rate->id,
             'period_count' => 10,
             'student_count' => 20,
         ]);
@@ -46,6 +47,7 @@ class PayrollTotalsTest extends TestCase
             'teacher_id' => $teacher->id,
             'subject_id' => $subject->id,
             'course_offering_id' => $offering2->id,
+            'teaching_rate_id' => $rate->id,
             'period_count' => 5,
             'student_count' => 20,
         ]);

--- a/tests/Unit/TeachingPaymentServiceTest.php
+++ b/tests/Unit/TeachingPaymentServiceTest.php
@@ -63,6 +63,7 @@ class TeachingPaymentServiceTest extends TestCase
             'course_offering_id' => $off1->id,
             'teacher_id' => $teacher->id,
             'subject_id' => $subject->id,
+            'teaching_rate_id' => $rate->id,
             'period_count' => 10,
             'student_count' => 30,
         ]);
@@ -71,6 +72,7 @@ class TeachingPaymentServiceTest extends TestCase
             'course_offering_id' => $off2->id,
             'teacher_id' => $teacher->id,
             'subject_id' => $subject->id,
+            'teaching_rate_id' => $rate->id,
             'period_count' => 10,
             'student_count' => 30,
         ]);


### PR DESCRIPTION
## Summary
- allow class sections to reference a teaching rate
- expose teaching rate dropdowns on class section forms
- include teaching rate in payroll calculations
- update seeders, factories and tests

## Testing
- `php artisan test --env=testing` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6850e8e92a7083259c752d3fcecc918f