### PR TITLE
Add hints for unique teacher/student codes

### DIFF
--- a/resources/views/students/create.blade.php
+++ b/resources/views/students/create.blade.php
@@ -25,6 +25,7 @@
                                 @error('student_id')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
+                                <div class="form-text">Mã sinh viên phải là duy nhất...</div>
                             </div>
                             <div class="col-md-6">
                                 <label for="class_id" class="form-label">{{ __('Lớp') }} <span class="text-danger">*</span></label>

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -26,6 +26,7 @@
                                 @error('student_id')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
+                                <div class="form-text">Mã sinh viên phải là duy nhất...</div>
                             </div>
                             <div class="col-md-6">
                                 <label for="class_id" class="form-label">{{ __('Lớp') }} <span class="text-danger">*</span></label>

--- a/resources/views/teachers/create.blade.php
+++ b/resources/views/teachers/create.blade.php
@@ -25,6 +25,7 @@
                                 @error('teacher_id')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
+                                <div class="form-text">Mã giáo viên phải là duy nhất...</div>
                             </div>
                             <div class="col-md-4">
                                 <label for="faculty_id" class="form-label">{{ __('Khoa') }} <span class="text-danger">*</span></label>

--- a/resources/views/teachers/edit.blade.php
+++ b/resources/views/teachers/edit.blade.php
@@ -26,6 +26,7 @@
                                 @error('teacher_id')
                                     <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
+                                <div class="form-text">Mã giáo viên phải là duy nhất...</div>
                             </div>
                             <div class="col-md-4">
                                 <label for="faculty_id" class="form-label">{{ __('Khoa') }} <span class="text-danger">*</span></label>


### PR DESCRIPTION
## Summary
- add unique code hint to teacher forms
- add unique code hint to student forms
- confirm other forms already show unique code hints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_b_6856b1e74d9883259d6d586fc4ef4820