### PR TITLE
Add reusable instructions alert

### DIFF
--- a/resources/views/academic_years/create.blade.php
+++ b/resources/views/academic_years/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('academic-years.store') }}">
                         @csrf

--- a/resources/views/academic_years/edit.blade.php
+++ b/resources/views/academic_years/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('academic-years.update', $academicYear->id) }}">
                         @csrf

--- a/resources/views/academic_years/index.blade.php
+++ b/resources/views/academic_years/index.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">

--- a/resources/views/class_sections/create.blade.php
+++ b/resources/views/class_sections/create.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <div class="mb-3">
                         <form action="{{ route('class-sections.create') }}" method="GET" class="row g-3">

--- a/resources/views/class_sections/edit.blade.php
+++ b/resources/views/class_sections/edit.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
                     <form method="POST" action="{{ route('class-sections.update', $classSection->id) }}">
                         @csrf
                         @method('PUT')

--- a/resources/views/class_sections/index.blade.php
+++ b/resources/views/class_sections/index.blade.php
@@ -18,6 +18,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">
                             <thead class="table-light">

--- a/resources/views/class_size_coefficients/create.blade.php
+++ b/resources/views/class_size_coefficients/create.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
                     <form method="POST" action="{{ route('class-size-coefficients.store') }}">
                         @csrf
                         <div class="mb-3">

--- a/resources/views/class_size_coefficients/edit.blade.php
+++ b/resources/views/class_size_coefficients/edit.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
                     <form method="POST" action="{{ route('class-size-coefficients.update', $classSizeCoefficient->id) }}">
                         @csrf
                         @method('PUT')

--- a/resources/views/class_size_coefficients/index.blade.php
+++ b/resources/views/class_size_coefficients/index.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">
                             <thead class="table-light">

--- a/resources/views/classes/create.blade.php
+++ b/resources/views/classes/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('classes.store') }}">
                         @csrf

--- a/resources/views/classes/edit.blade.php
+++ b/resources/views/classes/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('classes.update', $class->id) }}">
                         @csrf

--- a/resources/views/classes/index.blade.php
+++ b/resources/views/classes/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="mb-3">
                         <form action="{{ route('classes.index') }}" method="GET" class="row g-3">

--- a/resources/views/course_offerings/create.blade.php
+++ b/resources/views/course_offerings/create.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <div class="mb-3">
                         <form action="{{ route('course-offerings.create') }}" method="GET" class="row g-3">

--- a/resources/views/course_offerings/edit.blade.php
+++ b/resources/views/course_offerings/edit.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
                     <form method="POST" action="{{ route('course-offerings.update', $courseOffering->id) }}">
                         @csrf
                         @method('PUT')

--- a/resources/views/course_offerings/index.blade.php
+++ b/resources/views/course_offerings/index.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">
                             <thead class="table-light">

--- a/resources/views/degrees/create.blade.php
+++ b/resources/views/degrees/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('degrees.store') }}">
                         @csrf

--- a/resources/views/degrees/edit.blade.php
+++ b/resources/views/degrees/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('degrees.update', $degree->id) }}">
                         @csrf

--- a/resources/views/degrees/index.blade.php
+++ b/resources/views/degrees/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">

--- a/resources/views/enrollments/index.blade.php
+++ b/resources/views/enrollments/index.blade.php
@@ -8,6 +8,7 @@
                 <div class="card-header">Các lớp học phần đang mở</div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">
                             <thead class="table-light">

--- a/resources/views/faculties/create.blade.php
+++ b/resources/views/faculties/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('faculties.store') }}">
                         @csrf

--- a/resources/views/faculties/edit.blade.php
+++ b/resources/views/faculties/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('faculties.update', $faculty->id) }}">
                         @csrf

--- a/resources/views/faculties/index.blade.php
+++ b/resources/views/faculties/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">

--- a/resources/views/grades/create.blade.php
+++ b/resources/views/grades/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('grades.store') }}">
                         @csrf

--- a/resources/views/grades/edit.blade.php
+++ b/resources/views/grades/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('grades.update', $grade->id) }}">
                         @csrf

--- a/resources/views/grades/index.blade.php
+++ b/resources/views/grades/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="mb-3">
                         <form action="{{ route('grades.index') }}" method="GET" class="row g-3">

--- a/resources/views/majors/create.blade.php
+++ b/resources/views/majors/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('majors.store') }}">
                         @csrf

--- a/resources/views/majors/edit.blade.php
+++ b/resources/views/majors/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('majors.update', $major->id) }}">
                         @csrf

--- a/resources/views/majors/index.blade.php
+++ b/resources/views/majors/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="mb-3">
                         <form action="{{ route('majors.index') }}" method="GET" class="row g-3">

--- a/resources/views/partials/instructions.blade.php
+++ b/resources/views/partials/instructions.blade.php
@@ -1,0 +1,6 @@
+@if(!empty($guideline))
+    <div class="alert alert-info alert-dismissible fade show" role="alert">
+        {{ $guideline }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+@endif

--- a/resources/views/payrolls/index.blade.php
+++ b/resources/views/payrolls/index.blade.php
@@ -15,6 +15,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="mb-3">
                         <form action="{{ route('payrolls.index') }}" method="GET" class="row g-3">

--- a/resources/views/semesters/create.blade.php
+++ b/resources/views/semesters/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('semesters.store') }}">
                         @csrf

--- a/resources/views/semesters/edit.blade.php
+++ b/resources/views/semesters/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('semesters.update', $semester->id) }}">
                         @csrf

--- a/resources/views/semesters/index.blade.php
+++ b/resources/views/semesters/index.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">

--- a/resources/views/students/create.blade.php
+++ b/resources/views/students/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('students.store') }}">
                         @csrf

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('students.update', $student->id) }}">
                         @csrf

--- a/resources/views/students/index.blade.php
+++ b/resources/views/students/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="mb-3">
                         <form action="{{ route('students.index') }}" method="GET" class="row g-3">

--- a/resources/views/subjects/create.blade.php
+++ b/resources/views/subjects/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('subjects.store') }}">
                         @csrf

--- a/resources/views/subjects/edit.blade.php
+++ b/resources/views/subjects/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('subjects.update', $subject->id) }}">
                         @csrf

--- a/resources/views/subjects/index.blade.php
+++ b/resources/views/subjects/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="mb-3">
                         <form action="{{ route('subjects.index') }}" method="GET" class="row g-3">

--- a/resources/views/teachers/create.blade.php
+++ b/resources/views/teachers/create.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
 
                     <form method="POST" action="{{ route('teachers.store') }}">
                         @csrf

--- a/resources/views/teachers/edit.blade.php
+++ b/resources/views/teachers/edit.blade.php
@@ -14,6 +14,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
 
                     <form method="POST" action="{{ route('teachers.update', $teacher->id) }}">
                         @csrf

--- a/resources/views/teachers/index.blade.php
+++ b/resources/views/teachers/index.blade.php
@@ -16,6 +16,7 @@
 
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
 
                     <div class="mb-3">
                         <form action="{{ route('teachers.index') }}" method="GET" class="row g-3">

--- a/resources/views/teaching_rates/create.blade.php
+++ b/resources/views/teaching_rates/create.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Nhập đầy đủ thông tin và nhấn Lưu để tạo mới.'])
                     <form method="POST" action="{{ route('teaching-rates.store') }}">
                         @csrf
                         <div class="mb-3">

--- a/resources/views/teaching_rates/edit.blade.php
+++ b/resources/views/teaching_rates/edit.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Chỉnh sửa thông tin và nhấn Cập nhật để lưu thay đổi.'])
                     <form method="POST" action="{{ route('teaching-rates.update', $teachingRate->id) }}">
                         @csrf
                         @method('PUT')

--- a/resources/views/teaching_rates/index.blade.php
+++ b/resources/views/teaching_rates/index.blade.php
@@ -13,6 +13,7 @@
                 </div>
                 <div class="card-body">
                     @include('partials.alerts')
+                    @include('partials.instructions', ['guideline' => 'Sử dụng bộ lọc và ô tìm kiếm để lọc danh sách. Bạn có thể thêm, chỉnh sửa hoặc xoá bản ghi.'])
                     <div class="table-responsive">
                         <table class="table table-bordered table-hover">
                             <thead class="table-light">


### PR DESCRIPTION
## Summary
- add instructions partial
- show guideline alert on every list/create/edit view

## Testing
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856b3324a0c83258c2262965884a79f