### PR TITLE
Add PDF export for payroll section

### DIFF
--- a/resources/views/payrolls/section.blade.php
+++ b/resources/views/payrolls/section.blade.php
@@ -7,9 +7,12 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <span>Bảng lương lớp {{ $section->code }}</span>
-                    <a href="{{ route('payrolls.index') }}" class="btn btn-secondary btn-sm">
-                        <i class="fas fa-arrow-left"></i> Quay lại
-                    </a>
+                    <div>
+                        <a href="{{ route('payrolls.section_export', $section) }}" class="btn btn-primary btn-sm me-2">Xuất PDF</a>
+                        <a href="{{ route('payrolls.index') }}" class="btn btn-secondary btn-sm">
+                            <i class="fas fa-arrow-left"></i> Quay lại
+                        </a>
+                    </div>
                 </div>
                 <div class="card-body">
                     <table class="table table-bordered">

--- a/resources/views/payrolls/section_pdf.blade.php
+++ b/resources/views/payrolls/section_pdf.blade.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #000; padding: 4px; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <h1>Bảng lương lớp {{ $section->code }}</h1>
+    <table>
+        <tbody>
+            <tr>
+                <th>Giáo viên</th>
+                <td>{{ $teacher->full_name }}</td>
+            </tr>
+            <tr>
+                <th>Môn học</th>
+                <td>{{ $section->subject->name }}</td>
+            </tr>
+            <tr>
+                <th>Số tiết</th>
+                <td>{{ $section->period_count }}</td>
+            </tr>
+            <tr>
+                <th>Sĩ số</th>
+                <td>{{ $section->student_count }}</td>
+            </tr>
+            <tr>
+                <th>Hs học vị</th>
+                <td>{{ $detail['degree'] }}</td>
+            </tr>
+            <tr>
+                <th>Hs sĩ số</th>
+                <td>{{ $detail['class'] }}</td>
+            </tr>
+            <tr>
+                <th>Hs môn</th>
+                <td>{{ $detail['subject'] }}</td>
+            </tr>
+            <tr>
+                <th>Lương</th>
+                <td>{{ number_format($detail['salary'], 2) }}</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -98,6 +98,7 @@ Route::middleware(['auth', 'role:admin,teacher'])->group(function () {
     Route::get('payrolls/{teacher}/export', [PayrollController::class, 'exportDetail'])->name('payrolls.export_detail');
     Route::get('payrolls', [PayrollController::class, 'index'])->name('payrolls.index');
     Route::get('payrolls/{teacher}', [PayrollController::class, 'show'])->name('payrolls.show');
+    Route::get('payrolls/sections/{classSection}/export', [PayrollController::class, 'exportSection'])->name('payrolls.section_export');
     Route::get('payrolls/sections/{classSection}', [PayrollController::class, 'sectionDetail'])->name('payrolls.section');
 });
 

--- a/tests/Feature/PayrollPdfTest.php
+++ b/tests/Feature/PayrollPdfTest.php
@@ -49,5 +49,10 @@ class PayrollPdfTest extends TestCase
         $res = $this->actingAs($admin)->get(route('payrolls.export_detail', $teacher));
         $res->assertOk();
         $this->assertStringContainsString('application/pdf', $res->headers->get('content-type'));
+
+        $section = ClassSection::first();
+        $res = $this->actingAs($admin)->get(route('payrolls.section_export', $section));
+        $res->assertOk();
+        $this->assertStringContainsString('application/pdf', $res->headers->get('content-type'));
     }
 }


### PR DESCRIPTION
## Summary
- enable exporting individual class section payrolls to PDF
- add a PDF view for class section details
- provide an export button in the section page
- expose a route to download section payroll PDFs
- test PDF response for the new route

## Testing
- `php vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_b_6856bacb2d9c8325813dd5c5396de5bb