### PR TITLE
Fix openLabels string concatenation

### DIFF
--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -64,7 +64,7 @@
         options: {responsive: true, scales: {x: {stacked: true}, y: {stacked: true}}}
     });
 
-    const openLabels = @json(array_map(fn($d) => $d['faculty']+' - '+$d['semester'], $openRateData));
+    const openLabels = @json(array_map(fn($d) => $d['faculty'].' - '.$d['semester'], $openRateData));
     const openData = @json(array_column($openRateData, 'percent'));
     new Chart(document.getElementById('openRateChart').getContext('2d'), {
         type: 'bar',


### PR DESCRIPTION
## Summary
- correct the concatenation operator for the `openLabels` array in reports index

## Testing
- `php vendor/bin/phpunit` *(fails: could not find driver)*
- `pytest auto_test` *(fails: ProxyError when downloading chromedriver)*

------
https://chatgpt.com/codex/tasks/task_b_6856c54c6f3c8325b9176d6b6323c11e