### PR TITLE
Update driver fixture to prefer local Chrome driver

### DIFF
--- a/auto_test/conftest.py
+++ b/auto_test/conftest.py
@@ -1,6 +1,10 @@
+import os
+import shutil
+
 import pytest
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
 
 import config
@@ -12,7 +16,16 @@ def driver():
     options.add_argument("--headless=new")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
-    driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
+
+    # Attempt to use a pre-installed Chrome driver to avoid network downloads
+    driver_path = os.getenv("CHROME_DRIVER_PATH") or shutil.which("chromedriver")
+    if driver_path and os.path.exists(driver_path):
+        service = Service(driver_path)
+    else:
+        # Fallback to webdriver-manager which may download the driver
+        service = Service(ChromeDriverManager().install())
+
+    driver = webdriver.Chrome(service=service, options=options)
     driver.implicitly_wait(5)
     yield driver
     driver.quit()


### PR DESCRIPTION
## Summary
- avoid webdriver download if local driver is available

## Testing
- `pytest -k "nonexistent"` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_b_6856cbd04b4483258d5ce8804cedc8ab