### PR TITLE
Add assertions for CRUD listings

### DIFF
--- a/auto_test/test_faculty_crud.py
+++ b/auto_test/test_faculty_crud.py
@@ -7,6 +7,7 @@ def create_faculty(driver, base_url, name="Test Faculty"):
     driver.get(f"{base_url}/faculties/create")
     driver.find_element(By.ID, "name").send_keys(name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
 
 
 def edit_faculty(driver, base_url, new_name="Updated Faculty"):
@@ -15,19 +16,27 @@ def edit_faculty(driver, base_url, new_name="Updated Faculty"):
     name_field.clear()
     name_field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
 
 
 def delete_faculty(driver):
     driver.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
 
 
 def test_faculty_crud(driver, base_url):
     login_admin(driver, base_url)
-    create_faculty(driver, base_url)
-    assert "faculties" in driver.current_url
+    faculty_name = "Test Faculty"
+    updated_name = "Updated Faculty"
 
-    edit_faculty(driver, base_url)
+    create_faculty(driver, base_url, name=faculty_name)
     assert "faculties" in driver.current_url
+    assert faculty_name in driver.page_source
+
+    edit_faculty(driver, base_url, new_name=updated_name)
+    assert "faculties" in driver.current_url
+    assert updated_name in driver.page_source
 
     delete_faculty(driver)
     assert "faculties" in driver.current_url
+    assert updated_name not in driver.page_source

--- a/auto_test/test_student_crud.py
+++ b/auto_test/test_student_crud.py
@@ -12,6 +12,7 @@ def create_student(driver, base_url, name="Test Student", email="student_test@ex
     driver.find_element(By.ID, "password").send_keys("password")
     Select(driver.find_element(By.ID, "class_id")).select_by_index(1)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
 
 
 def edit_student(driver, base_url, new_name="Updated Student"):
@@ -20,19 +21,27 @@ def edit_student(driver, base_url, new_name="Updated Student"):
     name_field.clear()
     name_field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
 
 
 def delete_student(driver):
     driver.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
 
 
 def test_student_crud(driver, base_url):
     login_admin(driver, base_url)
-    create_student(driver, base_url)
-    assert "students" in driver.current_url
+    student_name = "Test Student"
+    updated_name = "Updated Student"
 
-    edit_student(driver, base_url)
+    create_student(driver, base_url, name=student_name)
     assert "students" in driver.current_url
+    assert student_name in driver.page_source
+
+    edit_student(driver, base_url, new_name=updated_name)
+    assert "students" in driver.current_url
+    assert updated_name in driver.page_source
 
     delete_student(driver)
     assert "students" in driver.current_url
+    assert updated_name not in driver.page_source

--- a/auto_test/test_subject_crud.py
+++ b/auto_test/test_subject_crud.py
@@ -8,12 +8,18 @@ def test_subject_crud(driver, base_url):
     driver.get(f"{base_url}/subjects/create")
     driver.find_element(By.ID, "name").send_keys("Test Subject")
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
     assert "subjects" in driver.current_url
+    assert "Test Subject" in driver.page_source
     driver.find_element(By.LINK_TEXT, "Edit").click()
     name_field = driver.find_element(By.ID, "name")
     name_field.clear()
     name_field.send_keys("Updated Subject")
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
     assert "subjects" in driver.current_url
+    assert "Updated Subject" in driver.page_source
     driver.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
     assert "subjects" in driver.current_url
+    assert "Updated Subject" not in driver.page_source


### PR DESCRIPTION
## Summary
- ensure student CRUD test checks the new name in the listing
- verify created/edit faculty names appear in test
- assert subject names are present after creating/editing

## Testing
- `python3 -m pip install -r auto_test/requirements.txt`
- `pytest auto_test/test_student_crud.py::test_student_crud -q` *(fails: ProxyError when downloading chromedriver)*

------
https://chatgpt.com/codex/tasks/task_b_6856cd24a3c8832582bbedd7c5483d0e