### PR TITLE
Add selenium tests for admin workflows

### DIFF
--- a/auto_test/test_academic_year_crud.py
+++ b/auto_test/test_academic_year_crud.py
@@ -1,0 +1,42 @@
+import time
+from selenium.webdriver.common.by import By
+from helpers import login_admin
+
+
+def create_year(driver, base_url, name="2025-2026"):
+    driver.get(f"{base_url}/academic-years/create")
+    driver.find_element(By.ID, "name").send_keys(name)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def edit_year(driver, name, new_name="2026-2027"):
+    row = driver.find_element(By.XPATH, f"//td[text()='{name}']/..")
+    row.find_element(By.CSS_SELECTOR, "a.btn-info").click()
+    field = driver.find_element(By.ID, "name")
+    field.clear()
+    field.send_keys(new_name)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def delete_year(driver, name):
+    row = driver.find_element(By.XPATH, f"//td[text()='{name}']/..")
+    row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
+
+
+def test_academic_year_crud(driver, base_url):
+    login_admin(driver, base_url)
+    name = "2025-2026"
+    create_year(driver, base_url, name)
+    assert "academic-years" in driver.current_url
+    assert name in driver.page_source
+
+    edit_year(driver, name, new_name="2026-2027")
+    assert "academic-years" in driver.current_url
+    assert "2026-2027" in driver.page_source
+
+    delete_year(driver, "2026-2027")
+    assert "academic-years" in driver.current_url
+    assert "2026-2027" not in driver.page_source

--- a/auto_test/test_class_crud.py
+++ b/auto_test/test_class_crud.py
@@ -1,0 +1,48 @@
+import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
+from helpers import login_admin
+
+
+def create_class(driver, base_url, code="CLTEST"):
+    driver.get(f"{base_url}/classes/create")
+    Select(driver.find_element(By.ID, "major_id")).select_by_index(1)
+    driver.find_element(By.ID, "name").send_keys("Test Class")
+    driver.find_element(By.ID, "code").send_keys(code)
+    year_field = driver.find_element(By.ID, "year")
+    year_field.clear()
+    year_field.send_keys("2024")
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def edit_class(driver, code, new_name="Updated Class"):
+    row = driver.find_element(By.XPATH, f"//td[text()='{code}']/..")
+    row.find_element(By.CSS_SELECTOR, "a.btn-info").click()
+    name_field = driver.find_element(By.ID, "name")
+    name_field.clear()
+    name_field.send_keys(new_name)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def delete_class(driver, code):
+    row = driver.find_element(By.XPATH, f"//td[text()='{code}']/..")
+    row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
+
+
+def test_class_crud(driver, base_url):
+    login_admin(driver, base_url)
+    code = "CLTEST"
+    create_class(driver, base_url, code)
+    assert "classes" in driver.current_url
+    assert code in driver.page_source
+
+    edit_class(driver, code, new_name="Class Updated")
+    assert "classes" in driver.current_url
+    assert "Class Updated" in driver.page_source
+
+    delete_class(driver, code)
+    assert "classes" in driver.current_url
+    assert code not in driver.page_source

--- a/auto_test/test_course_offering_workflow.py
+++ b/auto_test/test_course_offering_workflow.py
@@ -1,0 +1,33 @@
+import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
+from helpers import login_admin
+
+
+def create_course_offering(driver, base_url):
+    driver.get(f"{base_url}/course-offerings/create")
+    checkbox = driver.find_elements(By.CSS_SELECTOR, "input[name='subject_ids[]']")[0]
+    checkbox.click()
+    Select(driver.find_element(By.ID, "semester_id")).select_by_index(1)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def generate_class_section(driver, base_url):
+    driver.get(f"{base_url}/class-sections/create?auto=1")
+    Select(driver.find_element(By.NAME, "course_offering_id")).select_by_index(1)
+    Select(driver.find_element(By.NAME, "teacher_id")).select_by_index(1)
+    Select(driver.find_element(By.NAME, "teaching_rate_id")).select_by_index(1)
+    driver.find_element(By.NAME, "number_of_sections").clear()
+    driver.find_element(By.NAME, "number_of_sections").send_keys("1")
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def test_course_offering_and_class_section(driver, base_url):
+    login_admin(driver, base_url)
+    create_course_offering(driver, base_url)
+    assert "course-offerings" in driver.current_url
+
+    generate_class_section(driver, base_url)
+    assert "class-sections" in driver.current_url

--- a/auto_test/test_major_crud.py
+++ b/auto_test/test_major_crud.py
@@ -1,0 +1,45 @@
+import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
+from helpers import login_admin
+
+
+def create_major(driver, base_url, code="TMJ"):
+    driver.get(f"{base_url}/majors/create")
+    Select(driver.find_element(By.ID, "faculty_id")).select_by_index(1)
+    driver.find_element(By.ID, "name").send_keys("Test Major")
+    driver.find_element(By.ID, "code").send_keys(code)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def edit_major(driver, code, new_name="Updated Major"):
+    row = driver.find_element(By.XPATH, f"//td[text()='{code}']/..")
+    row.find_element(By.CSS_SELECTOR, "a.btn-info").click()
+    name_field = driver.find_element(By.ID, "name")
+    name_field.clear()
+    name_field.send_keys(new_name)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def delete_major(driver, code):
+    row = driver.find_element(By.XPATH, f"//td[text()='{code}']/..")
+    row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
+
+
+def test_major_crud(driver, base_url):
+    login_admin(driver, base_url)
+    code = "TMJ"
+    create_major(driver, base_url, code)
+    assert "majors" in driver.current_url
+    assert code in driver.page_source
+
+    edit_major(driver, code, new_name="Major Updated")
+    assert "majors" in driver.current_url
+    assert "Major Updated" in driver.page_source
+
+    delete_major(driver, code)
+    assert "majors" in driver.current_url
+    assert code not in driver.page_source

--- a/auto_test/test_payroll_export.py
+++ b/auto_test/test_payroll_export.py
@@ -1,0 +1,9 @@
+from selenium.webdriver.common.by import By
+from helpers import login_admin
+
+
+def test_payroll_export(driver, base_url):
+    login_admin(driver, base_url)
+    driver.get(f"{base_url}/payrolls")
+    driver.find_element(By.LINK_TEXT, "Xuất PDF").click()
+    assert "payrolls/export" in driver.current_url

--- a/auto_test/test_semester_crud.py
+++ b/auto_test/test_semester_crud.py
@@ -1,0 +1,44 @@
+import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
+from helpers import login_admin
+
+
+def create_semester(driver, base_url, name="HKTEST"):
+    driver.get(f"{base_url}/semesters/create")
+    driver.find_element(By.ID, "name").send_keys(name)
+    Select(driver.find_element(By.ID, "academic_year_id")).select_by_index(1)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def edit_semester(driver, name, new_name="HKUP"):
+    row = driver.find_element(By.XPATH, f"//td[text()='{name}']/..")
+    row.find_element(By.CSS_SELECTOR, "a.btn-info").click()
+    name_field = driver.find_element(By.ID, "name")
+    name_field.clear()
+    name_field.send_keys(new_name)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def delete_semester(driver, name):
+    row = driver.find_element(By.XPATH, f"//td[text()='{name}']/..")
+    row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
+
+
+def test_semester_crud(driver, base_url):
+    login_admin(driver, base_url)
+    name = "HKTEST"
+    create_semester(driver, base_url, name)
+    assert "semesters" in driver.current_url
+    assert name in driver.page_source
+
+    edit_semester(driver, name, new_name="HKUP")
+    assert "semesters" in driver.current_url
+    assert "HKUP" in driver.page_source
+
+    delete_semester(driver, "HKUP")
+    assert "semesters" in driver.current_url
+    assert "HKUP" not in driver.page_source

--- a/auto_test/test_teacher_crud.py
+++ b/auto_test/test_teacher_crud.py
@@ -1,0 +1,50 @@
+import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
+from helpers import login_admin
+
+
+def create_teacher(driver, base_url, teacher_id="GVTEST"):
+    driver.get(f"{base_url}/teachers/create")
+    driver.find_element(By.ID, "teacher_id").send_keys(teacher_id)
+    Select(driver.find_element(By.ID, "faculty_id")).select_by_index(1)
+    Select(driver.find_element(By.ID, "degree_id")).select_by_index(1)
+    driver.find_element(By.ID, "first_name").send_keys("Test")
+    driver.find_element(By.ID, "last_name").send_keys("Teacher")
+    Select(driver.find_element(By.ID, "gender")).select_by_value("Nam")
+    driver.find_element(By.ID, "date_of_birth").send_keys("1990-01-01")
+    driver.find_element(By.ID, "email").send_keys("teacher_test@example.com")
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def edit_teacher(driver, teacher_id, new_last="Updated"):
+    row = driver.find_element(By.XPATH, f"//td[text()='{teacher_id}']/..")
+    row.find_element(By.CSS_SELECTOR, "a.btn-info").click()
+    last_name = driver.find_element(By.ID, "last_name")
+    last_name.clear()
+    last_name.send_keys(new_last)
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    time.sleep(1)
+
+
+def delete_teacher(driver, teacher_id):
+    row = driver.find_element(By.XPATH, f"//td[text()='{teacher_id}']/..")
+    row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
+    time.sleep(1)
+
+
+def test_teacher_crud(driver, base_url):
+    login_admin(driver, base_url)
+    teacher_id = "GVTEST"
+    create_teacher(driver, base_url, teacher_id)
+    assert "teachers" in driver.current_url
+    assert teacher_id in driver.page_source
+
+    edit_teacher(driver, teacher_id, new_last="Updated")
+    assert "teachers" in driver.current_url
+    assert "Updated" in driver.page_source
+
+    delete_teacher(driver, teacher_id)
+    assert "teachers" in driver.current_url
+    assert teacher_id not in driver.page_source


### PR DESCRIPTION
## Summary
- add Selenium CRUD tests for teachers, classes, majors, semesters and academic years
- cover course offering & class section generation
- test payroll PDF export flow

## Testing
- `pip install -r auto_test/requirements.txt`
- `pytest -k test_teacher_crud -s` *(fails: Could not reach host for ChromeDriver)*

------
https://chatgpt.com/codex/tasks/task_b_6856ce104b4c8325951394bcbc81f3be