### PR TITLE
Update selenium docs

### DIFF
--- a/auto_test/README.md
+++ b/auto_test/README.md
@@ -5,12 +5,13 @@ This directory contains automated end-to-end tests written with Selenium and Pyt
 ## Setup
 
 1. Install Python 3.11+.
-2. Create and activate a virtual environment:
+2. Install Google Chrome or Chromium. The Selenium tests require a local Chrome/Chromium browser. The `chromedriver` binary is installed automatically via `webdriver-manager`, but you must have Chrome or Chromium installed. Optionally set `CHROME_DRIVER_PATH` if you need to specify a custom driver path.
+3. Create and activate a virtual environment:
    ```bash
    python3 -m venv venv
    source venv/bin/activate
    ```
-3. Install dependencies:
+4. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```


### PR DESCRIPTION
## Summary
- document need for local Chrome
- mention auto-installed chromedriver via webdriver-manager
- show `CHROME_DRIVER_PATH` option

## Testing
- `php artisan test` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_b_6856d74dbe7083258cdd62e62c2562c3