### PR TITLE
Improve Selenium login helpers

### DIFF
--- a/auto_test/helpers.py
+++ b/auto_test/helpers.py
@@ -1,23 +1,52 @@
 import config
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
+
+
+def login_user(role, driver, base_url, timeout=10):
+    """Log in as the specified role and wait for dashboard redirect.
+
+    Parameters
+    ----------
+    role: str
+        One of "admin", "teacher", or "student".
+    driver: WebDriver
+        Selenium WebDriver instance.
+    base_url: str
+        Base URL for the application.
+    timeout: int
+        Seconds to wait for the login redirect.
+    """
+    credentials_email = getattr(config, f"{role.upper()}_EMAIL")
+    credentials_password = getattr(config, f"{role.upper()}_PASSWORD")
+
+    driver.get(f"{base_url}/login")
+    driver.find_element(By.ID, "email").send_keys(credentials_email)
+    driver.find_element(By.ID, "password").send_keys(credentials_password)
+
+    previous_url = driver.current_url
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+
+    try:
+        WebDriverWait(driver, timeout).until(EC.url_changes(previous_url))
+        WebDriverWait(driver, timeout).until(EC.url_contains("/dashboard"))
+    except TimeoutException:
+        error_message = None
+        error_elems = driver.find_elements(By.CLASS_NAME, "alert")
+        if error_elems:
+            error_message = error_elems[0].text
+        raise AssertionError(f"Login failed for {role}: {error_message}")
 
 
 def login_admin(driver, base_url):
-    driver.get(f"{base_url}/login")
-    driver.find_element(By.ID, "email").send_keys(config.ADMIN_EMAIL)
-    driver.find_element(By.ID, "password").send_keys(config.ADMIN_PASSWORD)
-    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    login_user("admin", driver, base_url)
 
 
 def login_teacher(driver, base_url):
-    driver.get(f"{base_url}/login")
-    driver.find_element(By.ID, "email").send_keys(config.TEACHER_EMAIL)
-    driver.find_element(By.ID, "password").send_keys(config.TEACHER_PASSWORD)
-    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    login_user("teacher", driver, base_url)
 
 
 def login_student(driver, base_url):
-    driver.get(f"{base_url}/login")
-    driver.find_element(By.ID, "email").send_keys(config.STUDENT_EMAIL)
-    driver.find_element(By.ID, "password").send_keys(config.STUDENT_PASSWORD)
-    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+    login_user("student", driver, base_url)

--- a/auto_test/test_academic_year_crud.py
+++ b/auto_test/test_academic_year_crud.py
@@ -1,6 +1,6 @@
 import time
 from selenium.webdriver.common.by import By
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_year(driver, base_url, name="2025-2026"):
@@ -27,7 +27,7 @@ def delete_year(driver, name):
 
 
 def test_academic_year_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     name = f"2025-2026-{unique_suffix}"
 
     try:

--- a/auto_test/test_class_crud.py
+++ b/auto_test/test_class_crud.py
@@ -1,7 +1,7 @@
 import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_class(driver, base_url, code="CLTEST"):
@@ -33,7 +33,7 @@ def delete_class(driver, code):
 
 
 def test_class_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     code = f"CLTEST{unique_suffix}"
 
     try:

--- a/auto_test/test_course_offering_workflow.py
+++ b/auto_test/test_course_offering_workflow.py
@@ -1,7 +1,7 @@
 import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_course_offering(driver, base_url):
@@ -41,7 +41,7 @@ def delete_first_class_section(driver, base_url):
 
 
 def test_course_offering_and_class_section(driver, base_url):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
 
     try:
         create_course_offering(driver, base_url)

--- a/auto_test/test_enrollment.py
+++ b/auto_test/test_enrollment.py
@@ -1,10 +1,10 @@
 import config
 from selenium.webdriver.common.by import By
-from helpers import login_student
+from helpers import login_user
 
 
 def test_student_enrollment(driver, base_url):
-    login_student(driver, base_url)
+    login_user("student", driver, base_url)
     driver.get(f"{base_url}/enrollments")
     driver.find_element(By.CSS_SELECTOR, "a.enroll-btn").click()
     assert "enrollments" in driver.current_url

--- a/auto_test/test_faculty_crud.py
+++ b/auto_test/test_faculty_crud.py
@@ -1,6 +1,6 @@
 import config
 from selenium.webdriver.common.by import By
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_faculty(driver, base_url, name="Test Faculty"):
@@ -25,7 +25,7 @@ def delete_faculty(driver):
 
 
 def test_faculty_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     faculty_name = f"Test Faculty {unique_suffix}"
     updated_name = f"Updated Faculty {unique_suffix}"
 

--- a/auto_test/test_grade_management.py
+++ b/auto_test/test_grade_management.py
@@ -1,10 +1,10 @@
 import config
 from selenium.webdriver.common.by import By
-from helpers import login_teacher
+from helpers import login_user
 
 
 def test_grade_entry(driver, base_url):
-    login_teacher(driver, base_url)
+    login_user("teacher", driver, base_url)
     driver.get(f"{base_url}/grades")
     driver.find_element(By.LINK_TEXT, "Edit").click()
     score_input = driver.find_element(By.NAME, "score")

--- a/auto_test/test_login.py
+++ b/auto_test/test_login.py
@@ -1,23 +1,17 @@
 import config
-
-
-def login(driver, base_url, email, password):
-    driver.get(f"{base_url}/login")
-    driver.find_element("id", "email").send_keys(email)
-    driver.find_element("id", "password").send_keys(password)
-    driver.find_element("css selector", "button[type='submit']").click()
+from helpers import login_user
 
 
 def test_admin_login(driver, base_url):
-    login(driver, base_url, config.ADMIN_EMAIL, config.ADMIN_PASSWORD)
+    login_user("admin", driver, base_url)
     assert "/dashboard" in driver.current_url
 
 
 def test_teacher_login(driver, base_url):
-    login(driver, base_url, config.TEACHER_EMAIL, config.TEACHER_PASSWORD)
+    login_user("teacher", driver, base_url)
     assert "/dashboard" in driver.current_url
 
 
 def test_student_login(driver, base_url):
-    login(driver, base_url, config.STUDENT_EMAIL, config.STUDENT_PASSWORD)
+    login_user("student", driver, base_url)
     assert "/dashboard" in driver.current_url

--- a/auto_test/test_major_crud.py
+++ b/auto_test/test_major_crud.py
@@ -1,7 +1,7 @@
 import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_major(driver, base_url, code="TMJ"):
@@ -30,7 +30,7 @@ def delete_major(driver, code):
 
 
 def test_major_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     code = f"TMJ{unique_suffix}"
 
     try:

--- a/auto_test/test_payroll_export.py
+++ b/auto_test/test_payroll_export.py
@@ -1,9 +1,9 @@
 from selenium.webdriver.common.by import By
-from helpers import login_admin
+from helpers import login_user
 
 
 def test_payroll_export(driver, base_url):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     driver.get(f"{base_url}/payrolls")
     driver.find_element(By.LINK_TEXT, "Xuất PDF").click()
     assert "payrolls/export" in driver.current_url

--- a/auto_test/test_report_generation.py
+++ b/auto_test/test_report_generation.py
@@ -1,10 +1,10 @@
 import config
 from selenium.webdriver.common.by import By
-from helpers import login_admin
+from helpers import login_user
 
 
 def test_generate_reports(driver, base_url):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     driver.get(f"{base_url}/reports/sections")
     assert "reports" in driver.current_url
     driver.get(f"{base_url}/reports/workload")

--- a/auto_test/test_semester_crud.py
+++ b/auto_test/test_semester_crud.py
@@ -1,7 +1,7 @@
 import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_semester(driver, base_url, name="HKTEST"):
@@ -29,7 +29,7 @@ def delete_semester(driver, name):
 
 
 def test_semester_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     name = f"HKTEST{unique_suffix}"
 
     try:

--- a/auto_test/test_student_crud.py
+++ b/auto_test/test_student_crud.py
@@ -2,7 +2,7 @@ import config
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
 import time
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_student(driver, base_url, name="Test Student", email="student_test@example.com"):
@@ -30,7 +30,7 @@ def delete_student(driver):
 
 
 def test_student_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     student_name = f"Test Student {unique_suffix}"
     updated_name = f"Updated Student {unique_suffix}"
     email = f"student_test_{unique_suffix}@example.com"

--- a/auto_test/test_subject_crud.py
+++ b/auto_test/test_subject_crud.py
@@ -1,11 +1,11 @@
 import config
 import time
 from selenium.webdriver.common.by import By
-from helpers import login_admin
+from helpers import login_user
 
 
 def test_subject_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     name = f"Test Subject {unique_suffix}"
     updated = f"Updated Subject {unique_suffix}"
 

--- a/auto_test/test_teacher_crud.py
+++ b/auto_test/test_teacher_crud.py
@@ -1,7 +1,7 @@
 import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_admin
+from helpers import login_user
 
 
 def create_teacher(driver, base_url, teacher_id="GVTEST", email="teacher_test@example.com"):
@@ -35,7 +35,7 @@ def delete_teacher(driver, teacher_id):
 
 
 def test_teacher_crud(driver, base_url, unique_suffix):
-    login_admin(driver, base_url)
+    login_user("admin", driver, base_url)
     teacher_id = f"GVTEST{unique_suffix}"
     email = f"teacher_test_{unique_suffix}@example.com"
 


### PR DESCRIPTION
## Summary
- add a generic `login_user` helper with proper waits
- refactor wrapper helpers to use the new login helper
- update all tests to call `login_user`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_b_6856edd5ade083259154d8f114166cfe