### PR TITLE
Refactor Selenium waits in auto tests

### DIFF
--- a/auto_test/helpers.py
+++ b/auto_test/helpers.py
@@ -50,3 +50,22 @@ def login_teacher(driver, base_url):
 
 def login_student(driver, base_url):
     login_user("student", driver, base_url)
+
+
+def wait_for_visibility(driver, by, locator, timeout=10):
+    """Return element once visible."""
+    return WebDriverWait(driver, timeout).until(
+        EC.visibility_of_element_located((by, locator))
+    )
+
+
+def wait_for_clickable(driver, by, locator, timeout=10):
+    """Return element once clickable."""
+    return WebDriverWait(driver, timeout).until(
+        EC.element_to_be_clickable((by, locator))
+    )
+
+
+def wait_for_url_contains(driver, text, timeout=10):
+    """Wait until current URL contains given text."""
+    return WebDriverWait(driver, timeout).until(EC.url_contains(text))

--- a/auto_test/test_academic_year_crud.py
+++ b/auto_test/test_academic_year_crud.py
@@ -1,13 +1,12 @@
-import time
 from selenium.webdriver.common.by import By
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def create_year(driver, base_url, name="2025-2026"):
     driver.get(f"{base_url}/academic-years/create")
     driver.find_element(By.ID, "name").send_keys(name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_visibility(driver, By.XPATH, f"//td[text()='{name}']")
 
 
 def edit_year(driver, name, new_name="2026-2027"):
@@ -17,13 +16,13 @@ def edit_year(driver, name, new_name="2026-2027"):
     field.clear()
     field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "academic-years")
 
 
 def delete_year(driver, name):
     row = driver.find_element(By.XPATH, f"//td[text()='{name}']/..")
     row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "academic-years")
 
 
 def test_academic_year_crud(driver, base_url, unique_suffix):

--- a/auto_test/test_class_crud.py
+++ b/auto_test/test_class_crud.py
@@ -1,7 +1,6 @@
-import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def create_class(driver, base_url, code="CLTEST"):
@@ -13,7 +12,7 @@ def create_class(driver, base_url, code="CLTEST"):
     year_field.clear()
     year_field.send_keys("2024")
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_visibility(driver, By.XPATH, f"//td[text()='{code}']")
 
 
 def edit_class(driver, code, new_name="Updated Class"):
@@ -23,13 +22,13 @@ def edit_class(driver, code, new_name="Updated Class"):
     name_field.clear()
     name_field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "classes")
 
 
 def delete_class(driver, code):
     row = driver.find_element(By.XPATH, f"//td[text()='{code}']/..")
     row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "classes")
 
 
 def test_class_crud(driver, base_url, unique_suffix):

--- a/auto_test/test_course_offering_workflow.py
+++ b/auto_test/test_course_offering_workflow.py
@@ -1,7 +1,6 @@
-import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains
 
 
 def create_course_offering(driver, base_url):
@@ -10,7 +9,7 @@ def create_course_offering(driver, base_url):
     checkbox.click()
     Select(driver.find_element(By.ID, "semester_id")).select_by_index(1)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "course-offerings")
 
 
 def generate_class_section(driver, base_url):
@@ -21,7 +20,7 @@ def generate_class_section(driver, base_url):
     driver.find_element(By.NAME, "number_of_sections").clear()
     driver.find_element(By.NAME, "number_of_sections").send_keys("1")
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "class-sections")
 
 
 def delete_first_course_offering(driver, base_url):
@@ -29,7 +28,7 @@ def delete_first_course_offering(driver, base_url):
     buttons = driver.find_elements(By.CSS_SELECTOR, "form button[type='submit']")
     if buttons:
         buttons[0].click()
-        time.sleep(1)
+        wait_for_url_contains(driver, "course-offerings")
 
 
 def delete_first_class_section(driver, base_url):
@@ -37,7 +36,7 @@ def delete_first_class_section(driver, base_url):
     buttons = driver.find_elements(By.CSS_SELECTOR, "form button[type='submit']")
     if buttons:
         buttons[0].click()
-        time.sleep(1)
+        wait_for_url_contains(driver, "class-sections")
 
 
 def test_course_offering_and_class_section(driver, base_url):

--- a/auto_test/test_faculty_crud.py
+++ b/auto_test/test_faculty_crud.py
@@ -1,13 +1,13 @@
 import config
 from selenium.webdriver.common.by import By
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def create_faculty(driver, base_url, name="Test Faculty"):
     driver.get(f"{base_url}/faculties/create")
     driver.find_element(By.ID, "name").send_keys(name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_visibility(driver, By.XPATH, f"//td[text()='{name}']")
 
 
 def edit_faculty(driver, base_url, new_name="Updated Faculty"):
@@ -16,12 +16,12 @@ def edit_faculty(driver, base_url, new_name="Updated Faculty"):
     name_field.clear()
     name_field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "faculties")
 
 
 def delete_faculty(driver):
     driver.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "faculties")
 
 
 def test_faculty_crud(driver, base_url, unique_suffix):

--- a/auto_test/test_major_crud.py
+++ b/auto_test/test_major_crud.py
@@ -1,7 +1,6 @@
-import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def create_major(driver, base_url, code="TMJ"):
@@ -10,7 +9,7 @@ def create_major(driver, base_url, code="TMJ"):
     driver.find_element(By.ID, "name").send_keys("Test Major")
     driver.find_element(By.ID, "code").send_keys(code)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_visibility(driver, By.XPATH, f"//td[text()='{code}']")
 
 
 def edit_major(driver, code, new_name="Updated Major"):
@@ -20,13 +19,13 @@ def edit_major(driver, code, new_name="Updated Major"):
     name_field.clear()
     name_field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "majors")
 
 
 def delete_major(driver, code):
     row = driver.find_element(By.XPATH, f"//td[text()='{code}']/..")
     row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "majors")
 
 
 def test_major_crud(driver, base_url, unique_suffix):

--- a/auto_test/test_semester_crud.py
+++ b/auto_test/test_semester_crud.py
@@ -1,7 +1,6 @@
-import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def create_semester(driver, base_url, name="HKTEST"):
@@ -9,7 +8,7 @@ def create_semester(driver, base_url, name="HKTEST"):
     driver.find_element(By.ID, "name").send_keys(name)
     Select(driver.find_element(By.ID, "academic_year_id")).select_by_index(1)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_visibility(driver, By.XPATH, f"//td[text()='{name}']")
 
 
 def edit_semester(driver, name, new_name="HKUP"):
@@ -19,13 +18,13 @@ def edit_semester(driver, name, new_name="HKUP"):
     name_field.clear()
     name_field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "semesters")
 
 
 def delete_semester(driver, name):
     row = driver.find_element(By.XPATH, f"//td[text()='{name}']/..")
     row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "semesters")
 
 
 def test_semester_crud(driver, base_url, unique_suffix):

--- a/auto_test/test_student_crud.py
+++ b/auto_test/test_student_crud.py
@@ -1,8 +1,7 @@
 import config
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-import time
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def create_student(driver, base_url, name="Test Student", email="student_test@example.com"):
@@ -12,7 +11,7 @@ def create_student(driver, base_url, name="Test Student", email="student_test@ex
     driver.find_element(By.ID, "password").send_keys("password")
     Select(driver.find_element(By.ID, "class_id")).select_by_index(1)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_visibility(driver, By.XPATH, f"//td[text()='{name}']")
 
 
 def edit_student(driver, base_url, new_name="Updated Student"):
@@ -21,12 +20,12 @@ def edit_student(driver, base_url, new_name="Updated Student"):
     name_field.clear()
     name_field.send_keys(new_name)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "students")
 
 
 def delete_student(driver):
     driver.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "students")
 
 
 def test_student_crud(driver, base_url, unique_suffix):

--- a/auto_test/test_subject_crud.py
+++ b/auto_test/test_subject_crud.py
@@ -1,7 +1,6 @@
 import config
-import time
 from selenium.webdriver.common.by import By
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def test_subject_crud(driver, base_url, unique_suffix):
@@ -13,7 +12,7 @@ def test_subject_crud(driver, base_url, unique_suffix):
         driver.get(f"{base_url}/subjects/create")
         driver.find_element(By.ID, "name").send_keys(name)
         driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-        time.sleep(1)
+        wait_for_visibility(driver, By.XPATH, f"//td[text()='{name}']")
         assert "subjects" in driver.current_url
         assert name in driver.page_source
         driver.find_element(By.LINK_TEXT, "Edit").click()
@@ -21,12 +20,12 @@ def test_subject_crud(driver, base_url, unique_suffix):
         field.clear()
         field.send_keys(updated)
         driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-        time.sleep(1)
+        wait_for_url_contains(driver, "subjects")
         assert "subjects" in driver.current_url
         assert updated in driver.page_source
     finally:
         driver.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-        time.sleep(1)
+        wait_for_url_contains(driver, "subjects")
 
     assert "subjects" in driver.current_url
     assert updated not in driver.page_source

--- a/auto_test/test_teacher_crud.py
+++ b/auto_test/test_teacher_crud.py
@@ -1,7 +1,6 @@
-import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
-from helpers import login_user
+from helpers import login_user, wait_for_url_contains, wait_for_visibility
 
 
 def create_teacher(driver, base_url, teacher_id="GVTEST", email="teacher_test@example.com"):
@@ -15,7 +14,7 @@ def create_teacher(driver, base_url, teacher_id="GVTEST", email="teacher_test@ex
     driver.find_element(By.ID, "date_of_birth").send_keys("1990-01-01")
     driver.find_element(By.ID, "email").send_keys(email)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_visibility(driver, By.XPATH, f"//td[text()='{teacher_id}']")
 
 
 def edit_teacher(driver, teacher_id, new_last="Updated"):
@@ -25,13 +24,13 @@ def edit_teacher(driver, teacher_id, new_last="Updated"):
     last_name.clear()
     last_name.send_keys(new_last)
     driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "teachers")
 
 
 def delete_teacher(driver, teacher_id):
     row = driver.find_element(By.XPATH, f"//td[text()='{teacher_id}']/..")
     row.find_element(By.CSS_SELECTOR, "form button[type='submit']").click()
-    time.sleep(1)
+    wait_for_url_contains(driver, "teachers")
 
 
 def test_teacher_crud(driver, base_url, unique_suffix):


### PR DESCRIPTION
## Summary
- use explicit WebDriverWait helpers instead of `time.sleep`
- provide reusable wait utilities in `helpers.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ConnectionError while downloading chromedriver)*

------
https://chatgpt.com/codex/tasks/task_b_6856ff9bb93c8325bec721824bc15b8f