### PR TITLE
Add environment-variable based test configuration

### DIFF
--- a/auto_test/README.md
+++ b/auto_test/README.md
@@ -35,3 +35,20 @@ pytest --html=report.html
 ```
 
 Ensure the Laravel server is running before executing the tests.
+
+## Environment Variables
+
+The tests read several settings from environment variables. Defaults are used
+when variables are unset:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BASE_URL` | `http://127.0.0.1:8000` | Base URL where the Laravel application is served |
+| `ADMIN_EMAIL` | `admin@example.com` | Seeded admin account email |
+| `ADMIN_PASSWORD` | `password` | Password for the admin account |
+| `TEACHER_EMAIL` | `teacher1@example.com` | Seeded teacher account email |
+| `TEACHER_PASSWORD` | `password` | Password for the teacher account |
+| `STUDENT_EMAIL` | `student1@example.com` | Seeded student account email |
+| `STUDENT_PASSWORD` | `password` | Password for the student account |
+
+`CHROME_DRIVER_PATH` may also be set to specify a custom Chrome driver path.

--- a/auto_test/config.py
+++ b/auto_test/config.py
@@ -1,14 +1,15 @@
 # Configuration for Selenium tests
+import os
 
 # Base URL where the Laravel application is served
-BASE_URL = "http://127.0.0.1:8000"
+BASE_URL = os.getenv("BASE_URL", "http://127.0.0.1:8000")
 
 # Seeded user credentials
-ADMIN_EMAIL = "admin@example.com"
-ADMIN_PASSWORD = "password"
+ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@example.com")
+ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "password")
 
-TEACHER_EMAIL = "teacher1@example.com"
-TEACHER_PASSWORD = "password"
+TEACHER_EMAIL = os.getenv("TEACHER_EMAIL", "teacher1@example.com")
+TEACHER_PASSWORD = os.getenv("TEACHER_PASSWORD", "password")
 
-STUDENT_EMAIL = "student1@example.com"
-STUDENT_PASSWORD = "password"
+STUDENT_EMAIL = os.getenv("STUDENT_EMAIL", "student1@example.com")
+STUDENT_PASSWORD = os.getenv("STUDENT_PASSWORD", "password")


### PR DESCRIPTION
## Summary
- allow Selenium test config to read URLs and credentials from environment variables
- document new environment variables in `auto_test/README.md`

## Testing
- `pytest auto_test/test_login.py::test_admin_login -q` *(fails: Could not reach host)*

------
https://chatgpt.com/codex/tasks/task_b_685787946b9c83259b44f7f7ae4873d3