### PR TITLE
Add Selenium action delay option

### DIFF
--- a/auto_test/README.md
+++ b/auto_test/README.md
@@ -50,5 +50,10 @@ when variables are unset:
 | `TEACHER_PASSWORD` | `password` | Password for the teacher account |
 | `STUDENT_EMAIL` | `student1@example.com` | Seeded student account email |
 | `STUDENT_PASSWORD` | `password` | Password for the student account |
+| `ACTION_DELAY` | `0` | Seconds to pause after each Selenium action |
 
 `CHROME_DRIVER_PATH` may also be set to specify a custom Chrome driver path.
+
+To slow down the tests for debugging, export an `ACTION_DELAY` value. For
+example, running `export ACTION_DELAY=1` will wait one second after each
+Selenium step.

--- a/auto_test/config.py
+++ b/auto_test/config.py
@@ -13,3 +13,7 @@ TEACHER_PASSWORD = os.getenv("TEACHER_PASSWORD", "password")
 
 STUDENT_EMAIL = os.getenv("STUDENT_EMAIL", "student1@example.com")
 STUDENT_PASSWORD = os.getenv("STUDENT_PASSWORD", "password")
+
+# Optional delay (in seconds) inserted after each Selenium action. This can be
+# useful for visually observing test execution or for debugging timing issues.
+ACTION_DELAY = float(os.getenv("ACTION_DELAY", 0))

--- a/auto_test/helpers.py
+++ b/auto_test/helpers.py
@@ -6,6 +6,12 @@ from selenium.common.exceptions import TimeoutException, ElementClickIntercepted
 import time
 
 
+def delay():
+    """Pause execution for ``config.ACTION_DELAY`` seconds if configured."""
+    if config.ACTION_DELAY > 0:
+        time.sleep(config.ACTION_DELAY)
+
+
 def login_user(role, driver, base_url, timeout=10):
     """Log in as the specified role and wait for dashboard redirect.
 
@@ -24,11 +30,15 @@ def login_user(role, driver, base_url, timeout=10):
     credentials_password = getattr(config, f"{role.upper()}_PASSWORD")
 
     driver.get(f"{base_url}/login")
+    delay()
     wait_for_visibility(driver, By.ID, "email", timeout).send_keys(credentials_email)
+    delay()
     wait_for_visibility(driver, By.ID, "password", timeout).send_keys(credentials_password)
+    delay()
 
     previous_url = driver.current_url
     click_when_clickable(driver, By.CSS_SELECTOR, "button[type='submit']", timeout)
+    delay()
 
     try:
         WebDriverWait(driver, timeout).until(EC.url_changes(previous_url))
@@ -55,16 +65,20 @@ def login_student(driver, base_url):
 
 def wait_for_visibility(driver, by, locator, timeout=20):
     """Return element once visible."""
-    return WebDriverWait(driver, timeout).until(
+    element = WebDriverWait(driver, timeout).until(
         EC.visibility_of_element_located((by, locator))
     )
+    delay()
+    return element
 
 
 def wait_for_clickable(driver, by, locator, timeout=20):
     """Return element once clickable."""
-    return WebDriverWait(driver, timeout).until(
+    element = WebDriverWait(driver, timeout).until(
         EC.element_to_be_clickable((by, locator))
     )
+    delay()
+    return element
 
 
 def click_when_clickable(driver, by, locator, timeout=20):
@@ -72,6 +86,7 @@ def click_when_clickable(driver, by, locator, timeout=20):
     for attempt in range(3):
         try:
             wait_for_clickable(driver, by, locator, timeout).click()
+            delay()
             return
         except ElementClickInterceptedException:
             time.sleep(1)
@@ -85,8 +100,11 @@ def wait_until_element_disappear(driver, by, locator, timeout=20):
     WebDriverWait(driver, timeout).until_not(
         EC.presence_of_element_located((by, locator))
     )
+    delay()
 
 
 def wait_for_url_contains(driver, text, timeout=10):
     """Wait until current URL contains given text."""
-    return WebDriverWait(driver, timeout).until(EC.url_contains(text))
+    result = WebDriverWait(driver, timeout).until(EC.url_contains(text))
+    delay()
+    return result


### PR DESCRIPTION
## Summary
- allow configuring a pause between Selenium actions via `ACTION_DELAY`
- wait after actions by calling the new helper `delay()`
- document how to slow down tests in `auto_test/README.md`

## Testing
- `pytest -k "nonexistent"`

------
https://chatgpt.com/codex/tasks/task_b_6857f0d94dc48325a94bc876c9bdb93f