### PR TITLE
Update home redirect path

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/dashboard';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.


### PR DESCRIPTION
## Summary
- redirect authenticated users to `/dashboard` instead of `/home`

## Testing
- `pytest auto_test/test_academic_year_crud.py::test_academic_year_crud -q` *(fails: Service /usr/bin/chromedriver unexpectedly exited)*

------
https://chatgpt.com/codex/tasks/task_b_6857f79b0704832593eb5a251d7060c4